### PR TITLE
Set default window.styleMedia value to type:"screen"

### DIFF
--- a/lib/MediaQueryList.js
+++ b/lib/MediaQueryList.js
@@ -6,6 +6,7 @@ module.exports = function MediaQueryList(mediaQuery) {
   if (mediaQuery === undefined) throw new TypeError("Failed to execute 'matchMedia' on 'Window': 1 argument required, but only 0 present.");
 
   const window = this;
+  window.styleMedia = window.styleMedia || { type: "screen" };
   let matches = evaluate();
   const emitter = new EventEmitter();
 

--- a/test/window-test.js
+++ b/test/window-test.js
@@ -266,6 +266,12 @@ describe("Window", () => {
       expect(() => window.matchMedia()).to.throw(TypeError);
     });
 
+    it("should match 'screen' by default when styleMedia is undefined", () => {
+      const media = window.matchMedia("screen");
+      expect(media.media).to.equal("screen");
+      expect(media.matches).to.be.true;
+    });
+
     it("should return object that matches media type 'screen'", () => {
       window.styleMedia = { type: "screen" };
       const media = window.matchMedia("screen");


### PR DESCRIPTION
Upgrading from tallahassee 10.3 to >=10.4 

After that tallahaasee throws an exception 💥  `TypeError: Cannot read property 'type' of undefined` when running a test in my codebase that executes a clientside script with `window.matchMedia("print").matches` 

My test never defined `window.styleMedia` explicitly - we assume it's screen by default.

So the problem is that `window.styleMedia` is null in this tallahassee-function
```
function evaluateMediaTypes(types) {
      return types[0] === window.styleMedia.type;
}
```

Before version 10.4.0 of tallahassee had this line of code

`window.styleMedia = window.styleMedia || { type: "screen" };`

It was removed here:
https://github.com/BonnierNews/tallahassee/pull/90/files#diff-05031f01ca3c1fea02e05a188b3a3313ad06b1a9ea6d9c1e1704013bf3cedc5aL104


Now I'm bringing it back 😄 

## PS:

After talking with Jonas we've agreed this should result in a **minor** version bump when merged.