### PR TITLE
add readOnly property support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## Unreleased
+
+- Add `readOnly` property support
+
 ## 11.12.0
 
 - Accept options object as first argument when Tallahassee instance is created

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,5 +1,5 @@
 <!-- version -->
-# 11.11.0 API Reference
+# 11.12.0 API Reference
 <!-- versionstop -->
 
 <!-- toc -->

--- a/lib/HTMLInputElement.js
+++ b/lib/HTMLInputElement.js
@@ -29,6 +29,13 @@ module.exports = class HTMLInputElement extends Element {
     if (value === true) return this.setAttribute("disabled", "disabled");
     this.$elm.removeAttr("disabled");
   }
+  get readOnly() {
+    return this.$elm.prop("readonly");
+  }
+  set readOnly(value) {
+    if (value === true) return this.setAttribute("readonly", "readonly");
+    this.$elm.removeAttr("readonly");
+  }
   get value() {
     const value = this.getAttribute("value");
     if (value === undefined) return "";

--- a/lib/HTMLTextAreaElement.js
+++ b/lib/HTMLTextAreaElement.js
@@ -10,6 +10,13 @@ module.exports = class HTMLTextAreaElement extends Element {
     if (value === true) return this.setAttribute("disabled", "disabled");
     this.$elm.removeAttr("disabled");
   }
+  get readOnly() {
+    return this.$elm.prop("readonly");
+  }
+  set readOnly(value) {
+    if (value === true) return this.setAttribute("readonly", "readonly");
+    this.$elm.removeAttr("readonly");
+  }
   set innerHTML(value) {
     this.$elm.html(value);
     this.value = this.$elm.html();

--- a/test/form-test.js
+++ b/test/form-test.js
@@ -206,6 +206,36 @@ describe("forms", () => {
     });
   });
 
+  describe("readOnly", () => {
+    [ "input", "textarea" ].forEach((tagName) => {
+      it(`${tagName} have readOnly property`, () => {
+        const form = document.forms[0];
+        const elm = form.getElementsByTagName(tagName)[0];
+        expect(elm, tagName).to.have.property("readOnly");
+        elm.readOnly = true;
+      });
+
+      it(`${tagName} have value property`, () => {
+        const form = document.forms[0];
+        const elm = form.getElementsByTagName(tagName)[0];
+        expect(elm, tagName).to.have.property("value");
+
+        expect(elm.value = "val", "set value").to.equal("val");
+      });
+    });
+
+    it("h2 lacks readOnly and value property", () => {
+      const elm = document.getElementsByTagName("h2")[0];
+      expect(elm).to.not.have.property("readOnly");
+      expect(elm).to.not.have.property("value");
+    });
+
+    it("button lacks readOnly property", () => {
+      const elm = document.getElementsByTagName("button")[0];
+      expect(elm).to.not.have.property("readOnly");
+    });
+  });
+
   describe("validation", () => {
     beforeEach(() => {
       document = new Document({


### PR DESCRIPTION
Note that `readonly` attribute and `readOnly` property are _not_ the same

https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly