### PR TITLE
invalid events are now correctly being fired per input rather than the first one when validating form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## Unreleased
+
+- `invalid` events are now correctly being fired per input element when validating form rather than only the first one
+
 ## 11.15.0
 
 - add `invalid` event being dispatched on required element when submitting

--- a/lib/HTMLFormElement.js
+++ b/lib/HTMLFormElement.js
@@ -81,11 +81,13 @@ module.exports = class HTMLFormElement extends Element {
     this.dispatchEvent(new Event("reset", { bubbles: true }));
   }
   reportValidity() {
-    return [...this.elements].every((el) => {
-      if (el instanceof HTMLInputElement) {
-        return el.reportValidity();
-      }
-      return true;
-    });
+    return [...this.elements]
+      .map((el) => {
+        if (el instanceof HTMLInputElement) {
+          return el.reportValidity();
+        }
+        return true;
+      })
+      .every(Boolean);
   }
 };

--- a/lib/HTMLInputElement.js
+++ b/lib/HTMLInputElement.js
@@ -78,20 +78,15 @@ module.exports = class HTMLInputElement extends Element {
         ["pattern", (val, pattern) => new RegExp(`^(?:${pattern})$`).test(val)]
       ];
 
-      const valid = attributes.every(([key, processer]) => {
-        return Object.keys(this.$elm.attr())
-          .every((attr) => {
-            if (key !== attr) return true;
+      return attributes
+        .every(([key, processer]) => {
+          const attrVal = this.$elm.attr(key);
+          if (attrVal === undefined) return true;
 
-            return processer(this.value, this.getAttribute(attr));
-          });
-      });
-
-      if (!valid) {
-        this.dispatchEvent(new Event("invalid"));
-      }
-
-      return valid;
+          const valid = processer(this.value, attrVal);
+          if (!valid) this.dispatchEvent(new Event("invalid"));
+          return valid;
+        });
     }
 
     return true;

--- a/test/form-test.js
+++ b/test/form-test.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const { expect } = require("chai");
 const Document = require("../lib/Document");
 
 describe("forms", () => {

--- a/test/form-test.js
+++ b/test/form-test.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const { expect } = require("chai");
 const Document = require("../lib/Document");
 
 describe("forms", () => {
@@ -363,18 +364,28 @@ describe("forms", () => {
       expect(el.reportValidity()).to.equal(true);
     });
 
-    it("element should fire 'invalid' event if validation fails", (done) => {
-      const el = document.forms[0].req;
+    it("element should fire 'invalid' event for all elements if validation fails", () => {
+      const {req, reqsize} = document.forms[0];
       const button = document.getElementsByTagName("button")[0];
 
-      el.addEventListener("invalid", () => done());
-      el.value = "test";
+      let reqFired = 0;
+      let reqsizeFired = 0;
+      req.addEventListener("invalid", () => reqFired++);
+      reqsize.addEventListener("invalid", () => reqsizeFired++);
 
+      req.value = "test";
+      reqsize.value = "test";
       button.click();
 
-      el.value = "";
+      expect(reqFired).to.equal(0);
+      expect(reqsizeFired).to.equal(0);
 
+      req.value = "";
+      reqsize.value = "";
       button.click();
+
+      expect(reqFired).to.equal(1);
+      expect(reqsizeFired).to.equal(1);
     });
   });
 });


### PR DESCRIPTION
fix #132 