### PR TITLE
only form elements is now supported

### DIFF
--- a/lib/HTMLFormControlsCollection.js
+++ b/lib/HTMLFormControlsCollection.js
@@ -1,9 +1,32 @@
 "use strict";
 
 const HTMLCollection = require("./HTMLCollection");
+const RadioNodeList = require("./RadioNodeList");
 
 module.exports = class HTMLFormControlsCollection extends HTMLCollection {
   constructor(parentElement, selector) {
     super(parentElement, selector, { childList: true, attributes: true });
+
+    const element = this;
+
+    return new Proxy(element, {
+      has(target, prop) {
+        if (prop in target) return true;
+        if (Object.getOwnPropertyDescriptor(target, prop)) return true;
+        if (typeof prop === "symbol") return !!target[prop];
+        return !!element.querySelectorAll(`[name="${prop}"]`).length;
+      },
+      get(target, prop) {
+        if (typeof prop === "symbol") return target[prop];
+        const value = target[prop];
+        if (value !== undefined) return value;
+
+        const namedElement = parentElement.querySelector(`[name="${prop}"]`);
+        if (!namedElement) return;
+
+        if (namedElement.type === "radio") return new RadioNodeList(parentElement, prop);
+        return namedElement;
+      }
+    });
   }
 };

--- a/lib/HTMLFormElement.js
+++ b/lib/HTMLFormElement.js
@@ -3,7 +3,6 @@
 const { Event, SubmitEvent, symbols } = require("./Events");
 const Element = require("./Element");
 const HTMLFormControlsCollection = require("./HTMLFormControlsCollection");
-const RadioNodeList = require("./RadioNodeList");
 const HTMLInputElement = require("./HTMLInputElement");
 
 const originSymbol = Symbol.for("origin");
@@ -11,30 +10,8 @@ const originSymbol = Symbol.for("origin");
 module.exports = class HTMLFormElement extends Element {
   constructor(document, $elm) {
     super(document, $elm);
-    const element = this;
-    const nameHandler = {
-      has(target, prop) {
-        if (prop in target) return true;
-        if (Object.getOwnPropertyDescriptor(target, prop)) return true;
-        if (typeof prop === "symbol") return !!target[prop];
-        return !!element.$elm.find(`[name="${prop}"]`).length;
-      },
-      get(target, prop) {
-        if (typeof prop === "symbol") return target[prop];
-        const value = target[prop];
-        if (value !== undefined) return value;
-
-        const $namedElement = element.$elm.find(`[name="${prop}"]`).eq(0);
-        if (!$namedElement) return;
-
-        if ($namedElement.eq(0).attr("type") === "radio") return new RadioNodeList(element, prop);
-        return document._getElement($namedElement);
-      }
-    };
 
     this[originSymbol] = document.location.href;
-
-    return new Proxy(element, nameHandler);
   }
   get elements() {
     return new HTMLFormControlsCollection(this, "input[type!=image],button,select,textarea,fieldset,object,output");

--- a/lib/ValidityState.js
+++ b/lib/ValidityState.js
@@ -38,7 +38,7 @@ class ValidateInput {
     if (this.type === "radio") {
       if (!element.name) return element.required;
 
-      const nodeList = element.form[element.name];
+      const nodeList = element.form.elements[element.name];
       for (const el of Array.from(nodeList)) {
         if (el.required) return true;
       }
@@ -51,7 +51,7 @@ class ValidateInput {
     const element = this.element;
     if (this.type === "radio") {
       if (!element.name) return element.value;
-      return element.form[element.name].value;
+      return element.form.elements[element.name].value;
     }
     return element.value;
   }

--- a/test/FormData-test.js
+++ b/test/FormData-test.js
@@ -35,13 +35,13 @@ describe("FormData", () => {
   });
 
   it("includes checked checkbox entry", () => {
-    form.mycheck.checked = true;
+    form.elements.mycheck.checked = true;
     const entries = new FormData(form).entries();
     expect([...entries]).to.deep.equal([["mycheck", "1"], ["myinput", "Foo"]]);
   });
 
   it("can be converted into object directly from instance", () => {
-    form.mycheck.checked = true;
+    form.elements.mycheck.checked = true;
     const data = new FormData(form);
     expect(Object.fromEntries(data)).to.deep.equal({
       mycheck: "1",
@@ -51,9 +51,9 @@ describe("FormData", () => {
 
   it("returns empty strings if values are nulled", () => {
     const data = new FormData(form);
-    form.mycheck.checked = true;
-    form.mycheck.value = null;
-    form.myinput.value = null;
+    form.elements.mycheck.checked = true;
+    form.elements.mycheck.value = null;
+    form.elements.myinput.value = null;
     expect(Object.fromEntries(data)).to.deep.equal({
       mycheck: "on",
       myinput: "",
@@ -62,7 +62,7 @@ describe("FormData", () => {
 
   it("ignores fields without name", () => {
     const data = new FormData(form);
-    form.mycheck.checked = true;
+    form.elements.mycheck.checked = true;
     form.elements[1].name = "";
     expect(Object.fromEntries(data)).to.deep.equal({
       mycheck: "1",
@@ -71,8 +71,8 @@ describe("FormData", () => {
 
   it("ignores fields that are disabled", () => {
     const data = new FormData(form);
-    form.mycheck.checked = true;
-    form.mycheck.disabled = true;
+    form.elements.mycheck.checked = true;
+    form.elements.mycheck.disabled = true;
     expect(Object.fromEntries(data)).to.deep.equal({
       myinput: "Foo",
     });

--- a/test/HTMLFormElement-test.js
+++ b/test/HTMLFormElement-test.js
@@ -29,7 +29,7 @@ describe("HTMLFormElement", () => {
 
     it("form input can be addressed by name", () => {
       const form = document.getElementsByTagName("form")[0];
-      expect(form.foo.tagName).to.equal("INPUT");
+      expect(form.elements.foo.tagName).to.equal("INPUT");
     });
 
     it("form non-existing symbol property is falsy", () => {
@@ -51,7 +51,7 @@ describe("HTMLFormElement", () => {
       const form = document.forms[0];
       expect(form.elements.length).to.equal(7);
 
-      form.img.type = "text";
+      form.elements.img.type = "text";
 
       expect(form.elements.length).to.equal(8);
     });

--- a/test/HTMLInputElement-test.js
+++ b/test/HTMLInputElement-test.js
@@ -43,8 +43,8 @@ describe("HTMLInputElement", () => {
       button.click();
       expect(submitted).to.equal(false);
 
-      form.req.value = "test";
-      form.reqsize.value = "test";
+      form.elements.req.value = "test";
+      form.elements.reqsize.value = "test";
       button.click();
       expect(submitted).to.equal(true);
     });
@@ -53,15 +53,15 @@ describe("HTMLInputElement", () => {
       const form = document.forms[0];
       expect(form.reportValidity()).to.equal(false);
 
-      form.req.value = "test";
+      form.elements.req.value = "test";
       expect(form.reportValidity()).to.equal(false);
 
-      form.reqsize.value = "test";
+      form.elements.reqsize.value = "test";
       expect(form.reportValidity()).to.equal(true);
     });
 
     it("should get validity on element", () => {
-      const el = document.forms[0].req;
+      const el = document.forms[0].elements.req;
       expect(el.reportValidity()).to.equal(false);
 
       el.value = "test";
@@ -69,7 +69,7 @@ describe("HTMLInputElement", () => {
     });
 
     it("should get validity on optional element with min and max", () => {
-      const el = document.forms[0].size;
+      const el = document.forms[0].elements.size;
       expect(el.reportValidity()).to.equal(true);
 
       el.value = 10;
@@ -86,7 +86,7 @@ describe("HTMLInputElement", () => {
     });
 
     it("should get validity on number element with step", () => {
-      const el = document.forms[0].step;
+      const el = document.forms[0].elements.step;
       expect(el.reportValidity()).to.equal(true);
 
       el.value = 10;
@@ -103,7 +103,7 @@ describe("HTMLInputElement", () => {
     });
 
     it("should get validity on optional element with pattern", () => {
-      const el = document.forms[0].pattern;
+      const el = document.forms[0].elements.pattern;
       expect(el.reportValidity()).to.equal(true);
 
       el.value = "foo";
@@ -117,7 +117,7 @@ describe("HTMLInputElement", () => {
     });
 
     it("element should fire 'invalid' event for all elements if validation fails", () => {
-      const {req, reqsize} = document.forms[0];
+      const {req, reqsize} = document.forms[0].elements;
       const button = document.getElementsByTagName("button")[0];
 
       let reqFired = 0;
@@ -142,17 +142,17 @@ describe("HTMLInputElement", () => {
 
     it("type email reports type mismatch if no @ in value", () => {
       const form = document.forms[0];
-      const validity = form.mailme.validity;
+      const validity = form.elements.mailme.validity;
 
       expect(validity).to.have.property("typeMismatch", false);
       expect(validity).to.have.property("valid", true);
 
-      form.mailme.value = "bar";
+      form.elements.mailme.value = "bar";
 
       expect(validity).to.have.property("typeMismatch", true);
       expect(validity).to.have.property("valid", false);
 
-      form.mailme.value = "foo@bar";
+      form.elements.mailme.value = "foo@bar";
 
       expect(validity).to.have.property("typeMismatch", false);
       expect(validity).to.have.property("valid", true);
@@ -160,20 +160,20 @@ describe("HTMLInputElement", () => {
 
     it("required type email reports type mismatch if no @ in value", () => {
       const form = document.forms[0];
-      form.mailme.required = true;
-      const validity = form.mailme.validity;
+      form.elements.mailme.required = true;
+      const validity = form.elements.mailme.validity;
 
       expect(validity).to.have.property("valueMissing", true);
       expect(validity).to.have.property("typeMismatch", false);
       expect(validity).to.have.property("valid", false);
 
-      form.mailme.value = "bar";
+      form.elements.mailme.value = "bar";
 
       expect(validity).to.have.property("valueMissing", false);
       expect(validity).to.have.property("typeMismatch", true);
       expect(validity).to.have.property("valid", false);
 
-      form.mailme.value = "foo@bar";
+      form.elements.mailme.value = "foo@bar";
 
       expect(validity).to.have.property("valueMissing", false);
       expect(validity).to.have.property("typeMismatch", false);
@@ -182,18 +182,18 @@ describe("HTMLInputElement", () => {
 
     it("required type checkbox reports value missing if not checked", () => {
       const form = document.forms[0];
-      form.agree.required = true;
-      const validity = form.agree.validity;
+      form.elements.agree.required = true;
+      const validity = form.elements.agree.validity;
 
       expect(validity).to.have.property("valueMissing", true);
       expect(validity).to.have.property("valid", false);
 
-      form.agree.click();
+      form.elements.agree.click();
 
       expect(validity).to.have.property("valueMissing", false);
       expect(validity).to.have.property("valid", true);
 
-      form.agree.click();
+      form.elements.agree.click();
 
       expect(validity).to.have.property("valueMissing", true);
       expect(validity).to.have.property("valid", false);
@@ -201,7 +201,7 @@ describe("HTMLInputElement", () => {
 
     it("required type radio reports value missing if not checked", () => {
       const form = document.forms[0];
-      const list = form.interests;
+      const list = form.elements.interests;
       const validityOption0 = list[0].validity;
       const validityOption1 = list[1].validity;
 
@@ -238,7 +238,7 @@ describe("HTMLInputElement", () => {
 
     it("minlength and maxlength triggers validation", () => {
       const form = document.forms[0];
-      const input = form.reqsize;
+      const input = form.elements.reqsize;
       const validity = input.validity;
 
       expect(validity).to.have.property("valueMissing", true);
@@ -265,7 +265,7 @@ describe("HTMLInputElement", () => {
 
     it("type mail requires x@y", () => {
       const form = document.forms[0];
-      const input = form.mailme;
+      const input = form.elements.mailme;
       const validity = input.validity;
 
       input.required = true;
@@ -309,7 +309,7 @@ describe("HTMLInputElement", () => {
 
     it("type url requires URL", () => {
       const form = document.forms[0];
-      const input = form.uri;
+      const input = form.elements.uri;
       const validity = input.validity;
 
       input.required = true;
@@ -343,22 +343,22 @@ describe("HTMLInputElement", () => {
     describe("willValidate", () => {
       it("returns false if hidden, readOnly, or disabled", () => {
         const form = document.forms[0];
-        form.size.readOnly = true;
-        expect(form.size).to.have.property("willValidate", false);
-        expect(form.hide).to.have.property("willValidate", false);
+        form.elements.size.readOnly = true;
+        expect(form.elements.size).to.have.property("willValidate", false);
+        expect(form.elements.hide).to.have.property("willValidate", false);
 
-        form.pattern.disabled = true;
-        expect(form.pattern).to.have.property("willValidate", false);
+        form.elements.pattern.disabled = true;
+        expect(form.elements.pattern).to.have.property("willValidate", false);
       });
 
       it("returns true otherwise", () => {
         const form = document.forms[0];
-        expect(form.size).to.have.property("willValidate", true);
-        expect(form.req).to.have.property("willValidate", true);
-        expect(form.reqsize).to.have.property("willValidate", true);
-        expect(form.step).to.have.property("willValidate", true);
-        expect(form.pattern).to.have.property("willValidate", true);
-        expect(form.uri).to.have.property("willValidate", true);
+        expect(form.elements.size).to.have.property("willValidate", true);
+        expect(form.elements.req).to.have.property("willValidate", true);
+        expect(form.elements.reqsize).to.have.property("willValidate", true);
+        expect(form.elements.step).to.have.property("willValidate", true);
+        expect(form.elements.pattern).to.have.property("willValidate", true);
+        expect(form.elements.uri).to.have.property("willValidate", true);
       });
     });
   });
@@ -385,30 +385,30 @@ describe("HTMLInputElement", () => {
 
     it("setCustomValidity() without argument throws TypeError", () => {
       const form = document.forms[0];
-      expect(() => form.foo.setCustomValidity()).to.throw(TypeError, "Failed to execute 'setCustomValidity' on 'HTMLInputElement': 1 argument required, but only 0 present.");
+      expect(() => form.elements.foo.setCustomValidity()).to.throw(TypeError, "Failed to execute 'setCustomValidity' on 'HTMLInputElement': 1 argument required, but only 0 present.");
     });
 
     it("setCustomValidity(null) sets 'null'", () => {
       const form = document.forms[0];
-      form.foo.setCustomValidity(null);
-      expect(form.foo.validationMessage).to.equal("null");
+      form.elements.foo.setCustomValidity(null);
+      expect(form.elements.foo.validationMessage).to.equal("null");
     });
 
     it("setCustomValidity(undefined) sets 'undefined'", () => {
       const form = document.forms[0];
-      form.foo.setCustomValidity(undefined);
-      expect(form.foo.validationMessage).to.equal("undefined");
+      form.elements.foo.setCustomValidity(undefined);
+      expect(form.elements.foo.validationMessage).to.equal("undefined");
     });
 
     it("checkValidity() returns false if required input is empty", () => {
       const form = document.forms[0];
-      expect(form.foo.checkValidity()).to.equal(false);
+      expect(form.elements.foo.checkValidity()).to.equal(false);
     });
 
     it("checkValidity() returns true if required input is disabled", () => {
       const form = document.forms[0];
-      form.foo.disabled = true;
-      expect(form.foo.checkValidity()).to.equal(true);
+      form.elements.foo.disabled = true;
+      expect(form.elements.foo.checkValidity()).to.equal(true);
     });
 
     it("disabled required input is ignored", () => {
@@ -417,11 +417,11 @@ describe("HTMLInputElement", () => {
       let submitted = false;
       document.addEventListener("submit", () => submitted = true);
 
-      form.foo.disabled = true;
+      form.elements.foo.disabled = true;
       document.getElementById("submit-form").click();
       expect(submitted).to.be.true;
 
-      expect(form.foo.validationMessage).to.equal("");
+      expect(form.elements.foo.validationMessage).to.equal("");
     });
 
     it("form submit is prevented if input is required", () => {
@@ -431,8 +431,8 @@ describe("HTMLInputElement", () => {
       document.addEventListener("submit", () => submitted = true);
 
       document.getElementById("submit-form").click();
-      expect(form.foo.validationMessage).to.equal("Required");
-      expect(form.foo.validity).to.have.property("customError", true);
+      expect(form.elements.foo.validationMessage).to.equal("Required");
+      expect(form.elements.foo.validity).to.have.property("customError", true);
 
       expect(submitted).to.be.false;
     });
@@ -444,13 +444,13 @@ describe("HTMLInputElement", () => {
       document.addEventListener("submit", () => submitted = true);
 
       document.getElementById("submit-form").click();
-      expect(form.foo.validationMessage).to.equal("Required");
+      expect(form.elements.foo.validationMessage).to.equal("Required");
 
       expect(submitted).to.be.false;
 
-      form.foo.value = "a";
+      form.elements.foo.value = "a";
 
-      expect(form.foo.validationMessage).to.equal("");
+      expect(form.elements.foo.validationMessage).to.equal("");
 
       document.getElementById("submit-form").click();
 

--- a/test/HTMLTextAreaElement-test.js
+++ b/test/HTMLTextAreaElement-test.js
@@ -18,7 +18,7 @@ describe("HTMLTextAreaElement", () => {
   });
 
   it("innerText is empty if value is set", () => {
-    const elm = document.forms[0].novel;
+    const elm = document.forms[0].elements.novel;
     elm.value = "a";
     expect(elm.textContent).to.equal("");
   });

--- a/test/RadioNodeList-test.js
+++ b/test/RadioNodeList-test.js
@@ -21,23 +21,23 @@ describe("RadioNodeList", () => {
   });
 
   it("form should hold the RadioNodeList by name", () => {
-    expect(document.forms[0].choosewisely).to.be.ok;
+    expect(document.forms[0].elements.choosewisely).to.be.ok;
   });
 
   it("should have the same length as there are radio buttons", () => {
-    const list = document.forms[0].choosewisely;
+    const list = document.forms[0].elements.choosewisely;
     expect(list.length).to.equal(3);
   });
 
   it("removes element from list if node is deleted", () => {
-    const list = document.forms[0].choosewisely;
+    const list = document.forms[0].elements.choosewisely;
     expect(list.length).to.equal(3);
     document.forms[0].removeChild(list[0]);
     expect(list.length).to.equal(2);
   });
 
   it("holds value of the selected radio button", () => {
-    const list = document.forms[0].choosewisely;
+    const list = document.forms[0].elements.choosewisely;
     expect(list.value).to.equal("2");
 
     list[0].checked = true;
@@ -49,7 +49,7 @@ describe("RadioNodeList", () => {
 
   it("holds no value if no checked radio button", () => {
     const form = document.forms[0];
-    const list = form.choosewisely;
+    const list = form.elements.choosewisely;
     list[0].checked = false;
     list[1].checked = false;
     list[2].checked = false;
@@ -57,7 +57,7 @@ describe("RadioNodeList", () => {
   });
 
   it("toString() includes class name", () => {
-    const list = document.forms[0].choosewisely;
+    const list = document.forms[0].elements.choosewisely;
     expect(list.toString()).to.equal("[object RadioNodeList]");
   });
 });

--- a/test/element-attribute-eventhandlers-test.js
+++ b/test/element-attribute-eventhandlers-test.js
@@ -20,24 +20,24 @@ describe("element attribute eventhandler", () => {
 
   it("has access to window", () => {
     const form = browser.document.forms[0];
-    form.btn.click();
+    form.elements.btn.click();
 
     expect(browser.window.invalidForm).to.be.true;
   });
 
   it("has access to document", () => {
     const form = browser.document.forms[0];
-    form.foo.value = "abc";
+    form.elements.foo.value = "abc";
 
-    expect(form.btn.textContent).to.equal("Save changes");
+    expect(form.elements.btn.textContent).to.equal("Save changes");
   });
 
   it("has access to element", () => {
     const form = browser.document.forms[0];
-    form.foo.value = "abc";
-    form.bar.value = "a";
-    form.btn.click();
+    form.elements.foo.value = "abc";
+    form.elements.bar.value = "a";
+    form.elements.btn.click();
 
-    expect(form.bar.classList.contains("error")).to.be.true;
+    expect(form.elements.bar.classList.contains("error")).to.be.true;
   });
 });

--- a/test/form-test.js
+++ b/test/form-test.js
@@ -207,15 +207,9 @@ describe("forms", () => {
 
   it("named input field can be retreived by named property", () => {
     const form = document.getElementsByTagName("form")[0];
-    expect(form.myinput).to.be.ok;
-    expect(form.myinput.name).to.equal("myinput");
-    expect(form.myinput.tagName).to.equal("INPUT");
-  });
-
-  it("named input field is in form", () => {
-    const form = document.getElementsByTagName("form")[0];
-    expect("myinput" in form).to.be.true;
-    expect("abrakadabra" in form).to.be.false;
+    expect(form.elements.myinput).to.be.ok;
+    expect(form.elements.myinput.name).to.equal("myinput");
+    expect(form.elements.myinput.tagName).to.equal("INPUT");
   });
 
   it("unknown input field returns undefined", () => {


### PR DESCRIPTION
fix #154 

This is done in preparation for a possible migration to JSDom as they only support getting form elements using the `elements` property. This is even described at MDN as a better approach:
https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement#accessing_the_forms_elements