### PR TITLE
replaced `innerText` with `textContent`

### DIFF
--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -118,6 +118,6 @@ it("script navigates away by changing location", async () => {
   browser = await browser._pending;
 
   expect(browser.window.location.href).to.equal("https://www.example.local/landing");
-  expect(browser.document.body.innerText).to.contain("Success!");
+  expect(browser.document.body.textContent).to.contain("Success!");
 });
 ```

--- a/test/HTMLCollection-test.js
+++ b/test/HTMLCollection-test.js
@@ -227,7 +227,7 @@ describe("HTMLCollection", () => {
       document.body.appendChild(elm);
 
       expect(elements.length).to.equal(2);
-      expect(elements[1].innerText).to.equal("my new elm");
+      expect(elements[1].textContent).to.equal("my new elm");
     });
 
     it("updates empty list if node is inserted that match selector", () => {
@@ -240,7 +240,7 @@ describe("HTMLCollection", () => {
       document.body.appendChild(elm);
 
       expect(elements.length).to.equal(1);
-      expect(elements[0].innerText).to.equal("my new elm");
+      expect(elements[0].textContent).to.equal("my new elm");
     });
   });
 

--- a/test/HTMLTextAreaElement-test.js
+++ b/test/HTMLTextAreaElement-test.js
@@ -20,6 +20,6 @@ describe("HTMLTextAreaElement", () => {
   it("innerText is empty if value is set", () => {
     const elm = document.forms[0].novel;
     elm.value = "a";
-    expect(elm.innerText).to.equal("");
+    expect(elm.textContent).to.equal("");
   });
 });

--- a/test/anchor-test.js
+++ b/test/anchor-test.js
@@ -28,80 +28,80 @@ describe("Anchor", () => {
     });
 
     it("get href returns full href with protocol, domain, and path", () => {
-      expect(anchors[0].href, anchors[0].innerText).to.equal("https://example.com/test");
-      expect(anchors[1].href, anchors[1].innerText).to.equal("http://example.com/");
-      expect(anchors[2].href, anchors[2].innerText).to.equal("http://www.example.com/?w=1");
-      expect(anchors[3].href, anchors[3].innerText).to.equal("https://www.expressen.se/slug/");
-      expect(anchors[4].href, anchors[4].innerText).to.equal("https://www.expressen.se/?signed_out=true");
-      expect(anchors[5].href, anchors[5].innerText).to.equal("https://www.expressen.se/#tag");
-      expect(anchors[6].href, anchors[5].innerText).to.equal("http://localhost:30080/path");
+      expect(anchors[0].href, anchors[0].textContent).to.equal("https://example.com/test");
+      expect(anchors[1].href, anchors[1].textContent).to.equal("http://example.com/");
+      expect(anchors[2].href, anchors[2].textContent).to.equal("http://www.example.com/?w=1");
+      expect(anchors[3].href, anchors[3].textContent).to.equal("https://www.expressen.se/slug/");
+      expect(anchors[4].href, anchors[4].textContent).to.equal("https://www.expressen.se/?signed_out=true");
+      expect(anchors[5].href, anchors[5].textContent).to.equal("https://www.expressen.se/#tag");
+      expect(anchors[6].href, anchors[5].textContent).to.equal("http://localhost:30080/path");
     });
 
     it("get protocol returns href protocol", () => {
-      expect(anchors[0].protocol, anchors[0].innerText).to.equal("https:");
-      expect(anchors[1].protocol, anchors[1].innerText).to.equal("http:");
-      expect(anchors[2].protocol, anchors[2].innerText).to.equal("http:");
-      expect(anchors[3].protocol, anchors[3].innerText).to.equal("https:");
-      expect(anchors[4].protocol, anchors[4].innerText).to.equal("https:");
-      expect(anchors[5].protocol, anchors[5].innerText).to.equal("https:");
-      expect(anchors[6].protocol, anchors[6].innerText).to.equal("http:");
+      expect(anchors[0].protocol, anchors[0].textContent).to.equal("https:");
+      expect(anchors[1].protocol, anchors[1].textContent).to.equal("http:");
+      expect(anchors[2].protocol, anchors[2].textContent).to.equal("http:");
+      expect(anchors[3].protocol, anchors[3].textContent).to.equal("https:");
+      expect(anchors[4].protocol, anchors[4].textContent).to.equal("https:");
+      expect(anchors[5].protocol, anchors[5].textContent).to.equal("https:");
+      expect(anchors[6].protocol, anchors[6].textContent).to.equal("http:");
     });
 
     it("get hostname returns href hostname", () => {
-      expect(anchors[0].hostname, anchors[0].innerText).to.equal("example.com");
-      expect(anchors[1].hostname, anchors[1].innerText).to.equal("example.com");
-      expect(anchors[2].hostname, anchors[2].innerText).to.equal("www.example.com");
-      expect(anchors[3].hostname, anchors[3].innerText).to.equal("www.expressen.se");
-      expect(anchors[4].hostname, anchors[4].innerText).to.equal("www.expressen.se");
-      expect(anchors[5].hostname, anchors[5].innerText).to.equal("www.expressen.se");
-      expect(anchors[6].hostname, anchors[6].innerText).to.equal("localhost");
+      expect(anchors[0].hostname, anchors[0].textContent).to.equal("example.com");
+      expect(anchors[1].hostname, anchors[1].textContent).to.equal("example.com");
+      expect(anchors[2].hostname, anchors[2].textContent).to.equal("www.example.com");
+      expect(anchors[3].hostname, anchors[3].textContent).to.equal("www.expressen.se");
+      expect(anchors[4].hostname, anchors[4].textContent).to.equal("www.expressen.se");
+      expect(anchors[5].hostname, anchors[5].textContent).to.equal("www.expressen.se");
+      expect(anchors[6].hostname, anchors[6].textContent).to.equal("localhost");
     });
 
     it("get host returns href host", () => {
-      expect(anchors[0].host, anchors[0].innerText).to.equal("example.com");
-      expect(anchors[1].host, anchors[1].innerText).to.equal("example.com");
-      expect(anchors[2].host, anchors[2].innerText).to.equal("www.example.com");
-      expect(anchors[3].host, anchors[3].innerText).to.equal("www.expressen.se");
-      expect(anchors[4].host, anchors[4].innerText).to.equal("www.expressen.se");
-      expect(anchors[5].host, anchors[5].innerText).to.equal("www.expressen.se");
-      expect(anchors[6].host, anchors[6].innerText).to.equal("localhost:30080");
+      expect(anchors[0].host, anchors[0].textContent).to.equal("example.com");
+      expect(anchors[1].host, anchors[1].textContent).to.equal("example.com");
+      expect(anchors[2].host, anchors[2].textContent).to.equal("www.example.com");
+      expect(anchors[3].host, anchors[3].textContent).to.equal("www.expressen.se");
+      expect(anchors[4].host, anchors[4].textContent).to.equal("www.expressen.se");
+      expect(anchors[5].host, anchors[5].textContent).to.equal("www.expressen.se");
+      expect(anchors[6].host, anchors[6].textContent).to.equal("localhost:30080");
     });
 
     it("get port returns href port", () => {
-      expect(anchors[0].port, anchors[0].innerText).to.equal("");
-      expect(anchors[1].port, anchors[1].innerText).to.equal("");
-      expect(anchors[2].port, anchors[2].innerText).to.equal("");
-      expect(anchors[3].port, anchors[3].innerText).to.equal("");
-      expect(anchors[4].port, anchors[4].innerText).to.equal("");
-      expect(anchors[5].port, anchors[5].innerText).to.equal("");
-      expect(anchors[6].port, anchors[6].innerText).to.equal("30080");
+      expect(anchors[0].port, anchors[0].textContent).to.equal("");
+      expect(anchors[1].port, anchors[1].textContent).to.equal("");
+      expect(anchors[2].port, anchors[2].textContent).to.equal("");
+      expect(anchors[3].port, anchors[3].textContent).to.equal("");
+      expect(anchors[4].port, anchors[4].textContent).to.equal("");
+      expect(anchors[5].port, anchors[5].textContent).to.equal("");
+      expect(anchors[6].port, anchors[6].textContent).to.equal("30080");
     });
 
     it("get pathname returns href pathname", () => {
-      expect(anchors[0].pathname, anchors[0].innerText).to.equal("/test");
-      expect(anchors[1].pathname, anchors[1].innerText).to.equal("/");
-      expect(anchors[2].pathname, anchors[2].innerText).to.equal("/");
-      expect(anchors[3].pathname, anchors[3].innerText).to.equal("/slug/");
-      expect(anchors[4].pathname, anchors[4].innerText).to.equal("/");
-      expect(anchors[5].pathname, anchors[5].innerText).to.equal("/");
-      expect(anchors[6].pathname, anchors[6].innerText).to.equal("/path");
+      expect(anchors[0].pathname, anchors[0].textContent).to.equal("/test");
+      expect(anchors[1].pathname, anchors[1].textContent).to.equal("/");
+      expect(anchors[2].pathname, anchors[2].textContent).to.equal("/");
+      expect(anchors[3].pathname, anchors[3].textContent).to.equal("/slug/");
+      expect(anchors[4].pathname, anchors[4].textContent).to.equal("/");
+      expect(anchors[5].pathname, anchors[5].textContent).to.equal("/");
+      expect(anchors[6].pathname, anchors[6].textContent).to.equal("/path");
     });
 
     it("get search returns search if any", () => {
-      expect(anchors[0].search, anchors[0].innerText).to.equal("");
-      expect(anchors[1].search, anchors[1].innerText).to.equal("");
-      expect(anchors[2].search, anchors[2].innerText).to.equal("?w=1");
-      expect(anchors[3].search, anchors[2].innerText).to.equal("");
-      expect(anchors[4].search, anchors[4].innerText).to.equal("?signed_out=true");
+      expect(anchors[0].search, anchors[0].textContent).to.equal("");
+      expect(anchors[1].search, anchors[1].textContent).to.equal("");
+      expect(anchors[2].search, anchors[2].textContent).to.equal("?w=1");
+      expect(anchors[3].search, anchors[2].textContent).to.equal("");
+      expect(anchors[4].search, anchors[4].textContent).to.equal("?signed_out=true");
     });
 
     it("get hash returns hash if any", () => {
-      expect(anchors[0].hash, anchors[0].innerText).to.equal("");
-      expect(anchors[1].hash, anchors[1].innerText).to.equal("");
-      expect(anchors[2].hash, anchors[2].innerText).to.equal("");
-      expect(anchors[3].hash, anchors[2].innerText).to.equal("");
-      expect(anchors[4].hash, anchors[4].innerText).to.equal("");
-      expect(anchors[5].hash, anchors[5].innerText).to.equal("#tag");
+      expect(anchors[0].hash, anchors[0].textContent).to.equal("");
+      expect(anchors[1].hash, anchors[1].textContent).to.equal("");
+      expect(anchors[2].hash, anchors[2].textContent).to.equal("");
+      expect(anchors[3].hash, anchors[2].textContent).to.equal("");
+      expect(anchors[4].hash, anchors[4].textContent).to.equal("");
+      expect(anchors[5].hash, anchors[5].textContent).to.equal("#tag");
     });
 
     it("no href returns undefined", () => {

--- a/test/element-attribute-eventhandlers-test.js
+++ b/test/element-attribute-eventhandlers-test.js
@@ -29,7 +29,7 @@ describe("element attribute eventhandler", () => {
     const form = browser.document.forms[0];
     form.foo.value = "abc";
 
-    expect(form.btn.innerText).to.equal("Save changes");
+    expect(form.btn.textContent).to.equal("Save changes");
   });
 
   it("has access to element", () => {

--- a/test/elements-test.js
+++ b/test/elements-test.js
@@ -1678,7 +1678,7 @@ describe("elements", () => {
 
       expect(el.parentElement === document.body).to.equal(true);
 
-      expect(el.innerText).to.equal("åäö");
+      expect(el.textContent).to.equal("åäö");
       expect(el.dataset.json).to.equal("{\"var\":1}");
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -421,7 +421,7 @@ describe("Tallahassee", () => {
   describe("non 200 response", () => {
     it("can override expected status code", async () => {
       const browser = await Browser(app).navigateTo("/404", null, 404);
-      expect(browser.document.getElementsByTagName("h1")[0].innerText).to.equal("Apocalyptic");
+      expect(browser.document.getElementsByTagName("h1")[0].textContent).to.equal("Apocalyptic");
     });
 
   });


### PR DESCRIPTION
This is to make it easier in the future for a possible migration to JSDom since they don't support `innerText` and probably won't for a long time:
https://github.com/jsdom/jsdom/issues/1245