### PR TITLE
better handling of focus/blur events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## Unreleased
+
+- `blur` and `focus` events are now treated as `FocusEvent`
+- add `activeElement` to `document`
+
 ## 14.10.3
 
 - the `id` field of an element is `""` when not set (not `null`)

--- a/lib/Document.js
+++ b/lib/Document.js
@@ -21,6 +21,7 @@ const windowSymbol = Symbol.for("window");
 const referrerSymbol = Symbol.for("referrer");
 const fullscreenElementSymbol = Symbol.for("fullscreenElement");
 const kElementFactory = Symbol.for("element factory");
+const kActiveElement = Symbol.for("activeElement");
 
 module.exports = class Document extends Node {
   constructor(source, cookieJar, window) {
@@ -58,6 +59,9 @@ module.exports = class Document extends Node {
   }
   get body() {
     return this._getElement(this[kDollar]("body"));
+  }
+  get activeElement() {
+    return this[kActiveElement] || this.body;
   }
   get firstElementChild() {
     return this.documentElement;
@@ -161,6 +165,9 @@ module.exports = class Document extends Node {
   }
   querySelectorAll(selectors) {
     return new NodeList(this.documentElement, selectors, { disconnected: true });
+  }
+  _setActiveElement(element) {
+    this[kActiveElement] = element;
   }
   _getElement($elm) {
     const $ = this[kDollar];

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -4,7 +4,7 @@ const DOMException = require("domexception");
 const vm = require("vm");
 
 const { DOCUMENT_FRAGMENT_NODE, TEXT_NODE } = require("./nodeTypes.js");
-const { Event, PointerEvent } = require("./Events.js");
+const { Event } = require("./Events.js");
 const { getElementsByClassName, getElementsByTagName } = require("./getElements.js");
 const Attr = require("./Attr.js");
 const CSSStyleDeclaration = require("./CSSStyleDeclaration.js");
@@ -253,14 +253,6 @@ module.exports = class Element extends Node {
     } else if (childElement.textContent) {
       this.insertAdjacentHTML("beforeend", childElement.textContent);
     }
-  }
-  click() {
-    if (this.disabled) return;
-    if (this.nodeName === "SUMMARY") {
-      this.closest("details").open = !this.closest("details").open;
-    }
-
-    this.dispatchEvent(new PointerEvent("click", { bubbles: true }));
   }
   closest(selector) {
     return this._getElement(this.$elm.closest(selector));

--- a/lib/Events.js
+++ b/lib/Events.js
@@ -74,6 +74,14 @@ class PopStateEvent extends Event {
 
 class UIEvent extends Event {}
 
+class FocusEvent extends UIEvent {
+  constructor(type, options = {}) {
+    super(type, { bubbles: true });
+
+    this.relatedTarget = options.relatedTarget || null;
+  }
+}
+
 class InputEvent extends UIEvent {
   constructor(type) {
     super(type, { bubbles: true });
@@ -96,6 +104,7 @@ module.exports = {
   Event,
   CustomEvent,
   InputEvent,
+  FocusEvent,
   PointerEvent,
   SubmitEvent,
   PopStateEvent,

--- a/lib/HTMLButtonElement.js
+++ b/lib/HTMLButtonElement.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const { PointerEvent } = require("./Events.js");
 const HTMLElement = require("./HTMLElement.js");
 
 module.exports = class HTMLButtonElement extends HTMLElement {
@@ -43,11 +42,5 @@ module.exports = class HTMLButtonElement extends HTMLElement {
       default:
         return "submit";
     }
-  }
-  click() {
-    if (this.disabled) return;
-
-    const clickEvent = new PointerEvent("click", { bubbles: true });
-    this.dispatchEvent(clickEvent);
   }
 };

--- a/lib/HTMLElement.js
+++ b/lib/HTMLElement.js
@@ -2,26 +2,46 @@
 
 const Element = require("./Element.js");
 const DOMStringMap = require("./DOMStringMap.js");
-const { Event } = require("./Events.js");
+const { FocusEvent, PointerEvent } = require("./Events.js");
 
+const documentSymbol = Symbol.for("document");
 const datasetSymbol = Symbol.for("dataset");
 
 module.exports = class HTMLElement extends Element {
   constructor(document, $elm) {
     super(document, $elm);
 
+    this[documentSymbol] = document;
     this[datasetSymbol] = new DOMStringMap(this);
   }
 
   focus() {
     if (this.disabled) return;
-    const focusEvent = new Event("focus", { bubbles: true });
+    const doc = this[documentSymbol];
+    if (doc.activeElement !== this && doc.activeElement !== doc.body) {
+      doc.activeElement.blur(this);
+    }
+    doc._setActiveElement(this);
+    const focusEvent = new FocusEvent("focus", { bubbles: false });
     this.dispatchEvent(focusEvent);
   }
 
-  blur() {
-    const focusEvent = new Event("blur", { bubbles: true });
+  blur(relatedTarget = null) {
+    this[documentSymbol]._setActiveElement(null);
+    const focusEvent = new FocusEvent("blur", { bubbles: false, relatedTarget });
     this.dispatchEvent(focusEvent);
+  }
+
+  click() {
+    if (this.disabled) return;
+    if (this.nodeName === "SUMMARY") {
+      this.closest("details").open = !this.closest("details").open;
+    }
+    const doc = this[documentSymbol];
+    if (doc.activeElement !== this && doc.activeElement !== doc.body) {
+      doc.activeElement.blur(this);
+    }
+    this.dispatchEvent(new PointerEvent("click", { bubbles: true }));
   }
 
   get dataset() {

--- a/test/elements-test.js
+++ b/test/elements-test.js
@@ -1768,6 +1768,7 @@ describe("elements", () => {
       });
       buttons[0].focus();
       expect(focusCount).to.equal(1);
+      expect(document.activeElement).to.equal(buttons[0]);
     });
 
     it("listens to blur event", () => {
@@ -1776,6 +1777,18 @@ describe("elements", () => {
         ++blurCount;
       });
       buttons[0].blur();
+      expect(blurCount).to.equal(1);
+      expect(document.activeElement).to.equal(document.body);
+    });
+
+    it("when blurred receives relatedTarget", () => {
+      let blurCount = 0;
+      buttons[0].addEventListener("blur", (e) => {
+        expect(e.relatedTarget === buttons[1]);
+        ++blurCount;
+      });
+      buttons[0].focus();
+      buttons[1].click();
       expect(blurCount).to.equal(1);
     });
 


### PR DESCRIPTION
- new `FocusEvent` for focus and blur events with `relatedTarget`
- `document` now has `activeElement` property