### PR TITLE
fixed a bug with location objects not matching

### DIFF
--- a/lib/BrowserTab.js
+++ b/lib/BrowserTab.js
@@ -50,6 +50,7 @@ module.exports = class BrowserTab {
 
     const options = webPage.options;
     const window = this.window = new Window(resp, {
+      location: this.location,
       fetch: new Fetch(webPage.fetch.bind(webPage)),
       get document() {
         return document;

--- a/lib/Window.js
+++ b/lib/Window.js
@@ -37,7 +37,7 @@ module.exports = class Window {
     this[kOptions] = options;
 
     const webPageUrl = windowObjects.location ? windowObjects.location : resp.url;
-    const location = this[locationSymbol] = new Location(this, webPageUrl);
+    const location = this[locationSymbol] = windowObjects.location || new Location(this, webPageUrl);
 
     this[navigatorSymbol] = new Navigator(userAgent);
     this[historySymbol] = new History(this, location);

--- a/test/load-test.js
+++ b/test/load-test.js
@@ -51,6 +51,11 @@ describe("load", () => {
     return browser.window.fetch("/api").then((res) => res.json());
   });
 
+  it("browser and window location match", async () => {
+    const browser = await new Browser("https://www.expressen.se").load("");
+    expect(browser.location).to.equal(browser.window.location);
+  });
+
   it("window has location from implicit host", async () => {
     const browser = await new Browser().load("");
     expect(browser.window.location.href).to.equal("http://127.0.0.1/");

--- a/test/load-test.js
+++ b/test/load-test.js
@@ -51,9 +51,10 @@ describe("load", () => {
     return browser.window.fetch("/api").then((res) => res.json());
   });
 
-  it("browser and window location match", async () => {
+  it("location should match window and document", async () => {
     const browser = await new Browser("https://www.expressen.se").load("");
     expect(browser.location).to.equal(browser.window.location);
+    expect(browser.location).to.equal(browser.document.location);
   });
 
   it("window has location from implicit host", async () => {


### PR DESCRIPTION
If you would change the location by pushing state for instance it would only change the `window.location` object but not the global on `browser`. They should functionally be the same: https://developer.mozilla.org/en-US/docs/Web/API/Location