### PR TITLE
Fix for scroll listener warnings

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,5 +1,5 @@
 <!-- version -->
-# 16.0.0 API Reference
+# 16.0.1 API Reference
 <!-- versionstop -->
 
 <!-- toc -->

--- a/lib/IntersectionObserver.js
+++ b/lib/IntersectionObserver.js
@@ -15,6 +15,17 @@ module.exports = function fakeIntersectionObserver(browser) {
   const IntersectionObserverEntry = fakeIntersectionObserverEntry(browser);
   browser.window.IntersectionObserverEntry = IntersectionObserverEntry;
 
+  const eventHandlers = [];
+
+  function addEventHandler(handler) {
+    if (eventHandlers.length === 0) {
+      browser.window.addEventListener("scroll", () => {
+        eventHandlers.forEach((fn) => fn());
+      });
+    }
+    eventHandlers.push(handler);
+  }
+
   class IntersectionObserver {
     constructor(viewportUpdate, options) {
       this[kToObserve] = [];
@@ -23,7 +34,7 @@ module.exports = function fakeIntersectionObserver(browser) {
       this[kUpdate] = viewportUpdate;
       this[kRootMargin] = getRootMargin(options);
 
-      browser.window.addEventListener("scroll", () => {
+      addEventHandler(() => {
         const entries = this[kToObserve].map((el) => new IntersectionObserverEntry(el, this[kRootMargin]));
         const changedEntries = entries.filter((entry) => {
           const previous = this[kPrevEntries].find((x) => x.target === entry.target);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expressen/tallahassee",
-  "version": "16.0.0",
+  "version": "16.0.1",
   "description": "Lightweight client testing framework",
   "main": "index.js",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
When using a lot of `IntersectionObservers`, we would get console warnings that there were too many scroll listeners attached.

This small fix is to get rid of those warnings.