### PR TITLE
Ensure that pending requests doesn't resolve prematurely

### DIFF
--- a/lib/Fetch.js
+++ b/lib/Fetch.js
@@ -2,22 +2,32 @@
 
 module.exports = class Fetch {
   constructor(browserFetch) {
-    const stack = [];
+    const stack = new Map();
 
     function fetch(...args) {
+      const key = args;
       const request = browserFetch(...args);
 
-      const stackedProm = request.then(() => {
-        stack.pop();
-      }).catch(() => {
-        stack.pop();
-      });
-      stack.push(stackedProm);
+      const stackedProm = request
+        .then(() => {
+          stack.delete(key);
+          return [ null ].concat(args);
+        })
+        .catch((error) => {
+          stack.delete(key);
+          return [ error ].concat(args);
+        });
+
+      stack.set(key, stackedProm);
 
       return request;
     }
 
-    fetch._pendingRequests = stack;
+    Object.defineProperty(fetch, "_pendingRequests", {
+      get() {
+        return Array.from(stack.values());
+      },
+    });
 
     return fetch;
   }


### PR DESCRIPTION
```js
// code.js
fetch("/fast-resource");
fetch("/slow-resource");
```

```js
// test.js
await Promise.all(browser.window.fetch._pendingRequests);
```

Just pushing and popping the stack makes response of the `/fast-resource` pop the pending response for `/slow-resource` which causes the `Promise.all()` to resolve prematurely.

Having promises resolve with the arguments passed to `fetch()` is nice for debugging.

