### PR TITLE
Mutation observer fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## Unreleased
+
+- `MutationObserver`
+  - Support for `option.subtree`
+  - Replaced internal mutation events `_attributeChange`/`_insert` with `_mutation`
+
 ## 16.0.4
 
 - `Window` extends `EventTarget`

--- a/lib/DOMTokenList.js
+++ b/lib/DOMTokenList.js
@@ -16,14 +16,14 @@ module.exports = class DOMTokenList {
   add(...classNames) {
     const element = this[elementSymbol];
     element.$elm.addClass(classNames.join(" "));
+    element.setAttribute("class", element.$elm.attr("class"));
     element[emitterSymbol].emit("_classadded", ...classNames);
-    element[emitterSymbol].emit("_attributeChange", "class", element);
   }
   remove(...classNames) {
     const element = this[elementSymbol];
     element.$elm.removeClass(classNames.join(" "));
+    element.setAttribute("class", element.$elm.attr("class"));
     element[emitterSymbol].emit("_classremoved", ...classNames);
-    element[emitterSymbol].emit("_attributeChange", "class", element);
   }
   toggle(className, force) {
     const hasClass = this[elementSymbol].$elm.hasClass(className);

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -12,7 +12,7 @@ const HTMLCollection = require("./HTMLCollection.js");
 const Node = require("./Node.js");
 const NodeList = require("./NodeList.js");
 const eventnames = require("./eventnames.js");
-const { AttributeChangeEvent, InsertEvent } = require("./MutationObserver.js");
+const { MutationEvent } = require("./MutationObserver.js");
 
 const classListSymbol = Symbol.for("classList");
 const rectsSymbol = Symbol.for("rects");
@@ -124,7 +124,7 @@ module.exports = class Element extends Node {
   }
   set textContent(value) {
     const response = this.$elm.text(value);
-    this._emitter.emit("_insert");
+    this.dispatchEvent(new MutationEvent("characterData"));
     return response;
   }
   get innerText() {
@@ -239,7 +239,7 @@ module.exports = class Element extends Node {
         childElement._runScript();
       }
 
-      this.dispatchEvent(new InsertEvent());
+      this.dispatchEvent(new MutationEvent("childList"));
     } else if (childElement.textContent) {
       this.insertAdjacentHTML("beforeend", childElement.textContent);
     }
@@ -259,7 +259,7 @@ module.exports = class Element extends Node {
   }
   setAttribute(name, val) {
     this.$elm.attr(name, val);
-    this.dispatchEvent(new AttributeChangeEvent({ attributeName: name }));
+    this.dispatchEvent(new MutationEvent("attributes", { attributeName: name }));
   }
   getBoundingClientRect() {
     return this[rectsSymbol];
@@ -379,7 +379,7 @@ module.exports = class Element extends Node {
   removeAttribute(name) {
     if (!this.hasAttribute(name)) return;
     this.$elm.removeAttr(name);
-    this.dispatchEvent(new AttributeChangeEvent({ attributeName: name }));
+    this.dispatchEvent(new MutationEvent("attributes", { attributeName: name }));
   }
   requestFullscreen() {
     const fullscreenchangeEvent = new Event("fullscreenchange", { bubbles: true });

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -117,7 +117,7 @@ module.exports = class Element extends Node {
   }
   set innerHTML(value) {
     this.$elm.html(value);
-    this._emitter.emit("_insert");
+    this.dispatchEvent(new MutationEvent("childList"));
   }
   get textContent() {
     return this.$elm.text() || "";
@@ -138,7 +138,7 @@ module.exports = class Element extends Node {
   }
   set outerHTML(value) {
     this.$elm.replaceWith(this.ownerDocument.$(value));
-    this._emitter.emit("_insert");
+    this.dispatchEvent(new MutationEvent("childList"));
   }
   get src() {
     let rel = this.getAttribute("src");
@@ -282,19 +282,19 @@ module.exports = class Element extends Node {
     switch (position.toLowerCase()) {
       case "beforebegin":
         this.$elm.before(markup);
-        if (this.parentElement) this.parentElement._emitter.emit("_insert");
+        if (this.parentElement) this.parentElement.dispatchEvent(new MutationEvent("childList"));
         break;
       case "afterbegin":
         this.$elm.prepend(markup);
-        this._emitter.emit("_insert");
+        this.dispatchEvent(new MutationEvent("childList"));
         break;
       case "beforeend":
         this.$elm.append(markup);
-        this._emitter.emit("_insert");
+        this.dispatchEvent(new MutationEvent("childList"));
         break;
       case "afterend":
         this.$elm.after(markup);
-        if (this.parentElement) this.parentElement._emitter.emit("_insert");
+        if (this.parentElement) this.parentElement.dispatchEvent(new MutationEvent("childList"));
         break;
       default:
         throw new DOMException(`Failed to execute 'insertAdjacentHTML' on 'Element': The value provided (${position}) is not one of 'beforeBegin', 'afterBegin', 'beforeEnd', or 'afterEnd'.`);
@@ -304,19 +304,19 @@ module.exports = class Element extends Node {
     switch (position) {
       case "beforebegin":
         this.$elm.before(element.$elm);
-        if (this.parentElement) this.parentElement._emitter.emit("_insert");
+        if (this.parentElement) this.parentElement.dispatchEvent(new MutationEvent("childList"));
         break;
       case "afterbegin":
         this.$elm.prepend(element.$elm);
-        this._emitter.emit("_insert");
+        this.dispatchEvent(new MutationEvent("childList"));
         break;
       case "beforeend":
         this.$elm.append(element.$elm);
-        this._emitter.emit("_insert");
+        this.dispatchEvent(new MutationEvent("childList"));
         break;
       case "afterend":
         this.$elm.after(element.$elm);
-        if (this.parentElement) this.parentElement._emitter.emit("_insert");
+        if (this.parentElement) this.parentElement.dispatchEvent(new MutationEvent("childList"));
         break;
       default:
         throw new DOMException(`Failed to execute 'insertAdjacentElement' on 'Element': The value provided (${position}) is not one of 'beforeBegin', 'afterBegin', 'beforeEnd', or 'afterEnd'.`);
@@ -334,13 +334,13 @@ module.exports = class Element extends Node {
         throw new DOMException("Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.");
       }
       newNode.$elm.insertBefore(referenceNode.$elm);
-      this._emitter.emit("_insert");
+      this.dispatchEvent(new MutationEvent("childList"));
       return newNode;
     }
 
     if (newNode.textContent) {
       referenceNode.$elm.before(newNode.textContent);
-      this._emitter.emit("_insert");
+      this.dispatchEvent(new MutationEvent("childList"));
       return newNode;
     }
   }
@@ -354,7 +354,7 @@ module.exports = class Element extends Node {
   remove() {
     const parentElement = this.parentElement;
     this.$elm.remove();
-    parentElement?._emitter.emit("_insert");
+    parentElement?.dispatchEvent(new MutationEvent("childList"));
   }
   replaceChildren() {
     this.$elm.contents().remove();
@@ -362,7 +362,7 @@ module.exports = class Element extends Node {
       this.appendChild(child);
     }
     if (arguments.length === 0) {
-      this._emitter.emit("_insert");
+      this.dispatchEvent(new MutationEvent("childList"));
     }
   }
   replaceWith() {

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -124,7 +124,7 @@ module.exports = class Element extends Node {
   }
   set textContent(value) {
     const response = this.$elm.text(value);
-    this.dispatchEvent(new MutationEvent("characterData"));
+    this.dispatchEvent(new MutationEvent("childList"));
     return response;
   }
   get innerText() {

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -12,6 +12,7 @@ const HTMLCollection = require("./HTMLCollection.js");
 const Node = require("./Node.js");
 const NodeList = require("./NodeList.js");
 const eventnames = require("./eventnames.js");
+const { AttributeChangeEvent } = require("./MutationObserver.js");
 
 const classListSymbol = Symbol.for("classList");
 const rectsSymbol = Symbol.for("rects");
@@ -50,10 +51,6 @@ module.exports = class Element extends Node {
     this._emitter.on("_insert", (...args) => {
       if (this.parentElement) {
         this.parentElement._emitter.emit("_insert", ...args);
-      }
-    }).on("_attributeChange", (...args) => {
-      if (this.parentElement) {
-        this.parentElement._emitter.emit("_attributeChange", ...args);
       }
     });
   }
@@ -268,7 +265,7 @@ module.exports = class Element extends Node {
   }
   setAttribute(name, val) {
     this.$elm.attr(name, val);
-    this._emitter.emit("_attributeChange", name, this);
+    this.dispatchEvent(new AttributeChangeEvent({ attributeName: name }));
   }
   getBoundingClientRect() {
     return this[rectsSymbol];
@@ -388,7 +385,7 @@ module.exports = class Element extends Node {
   removeAttribute(name) {
     if (!this.hasAttribute(name)) return;
     this.$elm.removeAttr(name);
-    this._emitter.emit("_attributeChange", name, this);
+    this.dispatchEvent(new AttributeChangeEvent({ attributeName: name }));
   }
   requestFullscreen() {
     const fullscreenchangeEvent = new Event("fullscreenchange", { bubbles: true });

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -9,7 +9,6 @@ const eventnames = require("./eventnames.js");
 const HTMLCollection = require("./HTMLCollection.js");
 const Node = require("./Node.js");
 const NodeList = require("./NodeList.js");
-const { AttributesMutationEvent, ChildListMutationEvent } = require("./MutationObserver.js");
 const { DOCUMENT_FRAGMENT_NODE } = require("./nodeTypes.js");
 const { Event } = require("./Events.js");
 const { getElementsByClassName, getElementsByTagName } = require("./getElements.js");
@@ -117,14 +116,14 @@ module.exports = class Element extends Node {
   }
   set innerHTML(value) {
     this.$elm.html(value);
-    this._emitter.emit("ChildListMutationEvent", this);
+    this._registerMutation("childList");
   }
   get textContent() {
     return this.$elm.text() || "";
   }
   set textContent(value) {
     const response = this.$elm.text(value);
-    this._emitter.emit("ChildListMutationEvent", this);
+    this._registerMutation("childList");
     return response;
   }
   get innerText() {
@@ -138,7 +137,7 @@ module.exports = class Element extends Node {
   }
   set outerHTML(value) {
     this.$elm.replaceWith(this.ownerDocument.$(value));
-    this._emitter.emit("ChildListMutationEvent", this);
+    this._registerMutation("childList");
   }
   get src() {
     let rel = this.getAttribute("src");
@@ -239,7 +238,7 @@ module.exports = class Element extends Node {
         childElement._runScript();
       }
 
-      this._emitter.emit("ChildListMutationEvent", this);
+      this._registerMutation("childList");
     } else if (childElement.textContent) {
       this.insertAdjacentHTML("beforeend", childElement.textContent);
     }
@@ -259,7 +258,7 @@ module.exports = class Element extends Node {
   }
   setAttribute(name, val) {
     this.$elm.attr(name, val);
-    this._emitter.emit("AttributesMutationEvent", { attributeName: name }, this);
+    this._registerMutation("attributes", { attributeName: name });
   }
   getBoundingClientRect() {
     return this[rectsSymbol];
@@ -282,19 +281,19 @@ module.exports = class Element extends Node {
     switch (position.toLowerCase()) {
       case "beforebegin":
         this.$elm.before(markup);
-        if (this.parentElement) this.parentElement._emitter.emit("ChildListMutationEvent", this.parentElement);
+        if (this.parentElement) this.parentElement._registerMutation("childList");
         break;
       case "afterbegin":
         this.$elm.prepend(markup);
-        this._emitter.emit("ChildListMutationEvent", this);
+        this._registerMutation("childList");
         break;
       case "beforeend":
         this.$elm.append(markup);
-        this._emitter.emit("ChildListMutationEvent", this);
+        this._registerMutation("childList");
         break;
       case "afterend":
         this.$elm.after(markup);
-        if (this.parentElement) this.parentElement._emitter.emit("ChildListMutationEvent", this.parentElement);
+        if (this.parentElement) this.parentElement._registerMutation("childList");
         break;
       default:
         throw new DOMException(`Failed to execute 'insertAdjacentHTML' on 'Element': The value provided (${position}) is not one of 'beforeBegin', 'afterBegin', 'beforeEnd', or 'afterEnd'.`);
@@ -304,19 +303,19 @@ module.exports = class Element extends Node {
     switch (position) {
       case "beforebegin":
         this.$elm.before(element.$elm);
-        if (this.parentElement) this.parentElement._emitter.emit("ChildListMutationEvent", this.parentElement);
+        if (this.parentElement) this.parentElement._registerMutation("childList");
         break;
       case "afterbegin":
         this.$elm.prepend(element.$elm);
-        this._emitter.emit("ChildListMutationEvent", this);
+        this._registerMutation("childList");
         break;
       case "beforeend":
         this.$elm.append(element.$elm);
-        this._emitter.emit("ChildListMutationEvent", this);
+        this._registerMutation("childList");
         break;
       case "afterend":
         this.$elm.after(element.$elm);
-        if (this.parentElement) this.parentElement._emitter.emit("ChildListMutationEvent", this.parentElement);
+        if (this.parentElement) this.parentElement._registerMutation("childList");
         break;
       default:
         throw new DOMException(`Failed to execute 'insertAdjacentElement' on 'Element': The value provided (${position}) is not one of 'beforeBegin', 'afterBegin', 'beforeEnd', or 'afterEnd'.`);
@@ -334,13 +333,13 @@ module.exports = class Element extends Node {
         throw new DOMException("Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.");
       }
       newNode.$elm.insertBefore(referenceNode.$elm);
-      this._emitter.emit("ChildListMutationEvent", this);
+      this._registerMutation("childList");
       return newNode;
     }
 
     if (newNode.textContent) {
       referenceNode.$elm.before(newNode.textContent);
-      this._emitter.emit("ChildListMutationEvent", this);
+      this._registerMutation("childList");
       return newNode;
     }
   }
@@ -354,7 +353,7 @@ module.exports = class Element extends Node {
   remove() {
     const parentElement = this.parentElement;
     this.$elm.remove();
-    parentElement?._emitter.emit("ChildListMutationEvent", parentElement);
+    parentElement?._registerMutation("childList");
   }
   replaceChildren() {
     this.$elm.contents().remove();
@@ -362,7 +361,7 @@ module.exports = class Element extends Node {
       this.appendChild(child);
     }
     if (arguments.length === 0) {
-      this._emitter.emit("ChildListMutationEvent", this);
+      this._registerMutation("childList");
     }
   }
   replaceWith() {
@@ -379,7 +378,7 @@ module.exports = class Element extends Node {
   removeAttribute(name) {
     if (!this.hasAttribute(name)) return;
     this.$elm.removeAttr(name);
-    this._emitter.emit("AttributesMutationEvent", { attributeName: name }, this);
+    this._registerMutation("attributes", { attributeName: name });
   }
   requestFullscreen() {
     const fullscreenchangeEvent = new Event("fullscreenchange", { bubbles: true });

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -359,11 +359,10 @@ module.exports = class Element extends Node {
   replaceChildren() {
     this.$elm.contents().remove();
     for (const child of arguments) {
-      this.appendChild(child);
+      this.$elm.append(child.$elm);
     }
-    if (arguments.length === 0) {
-      this._registerMutation("childList");
-    }
+
+    this._registerMutation("childList");
   }
   replaceWith() {
     const params = [];

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -2,17 +2,17 @@
 
 const vm = require("vm");
 
-const { DOCUMENT_FRAGMENT_NODE } = require("./nodeTypes.js");
-const { Event } = require("./Events.js");
-const { getElementsByClassName, getElementsByTagName } = require("./getElements.js");
 const Attr = require("./Attr.js");
 const CSSStyleDeclaration = require("./CSSStyleDeclaration.js");
 const DOMTokenList = require("./DOMTokenList.js");
+const eventnames = require("./eventnames.js");
 const HTMLCollection = require("./HTMLCollection.js");
 const Node = require("./Node.js");
 const NodeList = require("./NodeList.js");
-const eventnames = require("./eventnames.js");
-const { MutationEvent } = require("./MutationObserver.js");
+const { AttributesMutationEvent, ChildListMutationEvent } = require("./MutationObserver.js");
+const { DOCUMENT_FRAGMENT_NODE } = require("./nodeTypes.js");
+const { Event } = require("./Events.js");
+const { getElementsByClassName, getElementsByTagName } = require("./getElements.js");
 
 const classListSymbol = Symbol.for("classList");
 const rectsSymbol = Symbol.for("rects");
@@ -117,14 +117,14 @@ module.exports = class Element extends Node {
   }
   set innerHTML(value) {
     this.$elm.html(value);
-    this.dispatchEvent(new MutationEvent("childList"));
+    this.dispatchEvent(new ChildListMutationEvent());
   }
   get textContent() {
     return this.$elm.text() || "";
   }
   set textContent(value) {
     const response = this.$elm.text(value);
-    this.dispatchEvent(new MutationEvent("childList"));
+    this.dispatchEvent(new ChildListMutationEvent());
     return response;
   }
   get innerText() {
@@ -138,7 +138,7 @@ module.exports = class Element extends Node {
   }
   set outerHTML(value) {
     this.$elm.replaceWith(this.ownerDocument.$(value));
-    this.dispatchEvent(new MutationEvent("childList"));
+    this.dispatchEvent(new ChildListMutationEvent());
   }
   get src() {
     let rel = this.getAttribute("src");
@@ -239,7 +239,7 @@ module.exports = class Element extends Node {
         childElement._runScript();
       }
 
-      this.dispatchEvent(new MutationEvent("childList"));
+      this.dispatchEvent(new ChildListMutationEvent());
     } else if (childElement.textContent) {
       this.insertAdjacentHTML("beforeend", childElement.textContent);
     }
@@ -259,7 +259,7 @@ module.exports = class Element extends Node {
   }
   setAttribute(name, val) {
     this.$elm.attr(name, val);
-    this.dispatchEvent(new MutationEvent("attributes", { attributeName: name }));
+    this.dispatchEvent(new AttributesMutationEvent({ attributeName: name }));
   }
   getBoundingClientRect() {
     return this[rectsSymbol];
@@ -282,19 +282,19 @@ module.exports = class Element extends Node {
     switch (position.toLowerCase()) {
       case "beforebegin":
         this.$elm.before(markup);
-        if (this.parentElement) this.parentElement.dispatchEvent(new MutationEvent("childList"));
+        if (this.parentElement) this.parentElement.dispatchEvent(new ChildListMutationEvent());
         break;
       case "afterbegin":
         this.$elm.prepend(markup);
-        this.dispatchEvent(new MutationEvent("childList"));
+        this.dispatchEvent(new ChildListMutationEvent());
         break;
       case "beforeend":
         this.$elm.append(markup);
-        this.dispatchEvent(new MutationEvent("childList"));
+        this.dispatchEvent(new ChildListMutationEvent());
         break;
       case "afterend":
         this.$elm.after(markup);
-        if (this.parentElement) this.parentElement.dispatchEvent(new MutationEvent("childList"));
+        if (this.parentElement) this.parentElement.dispatchEvent(new ChildListMutationEvent());
         break;
       default:
         throw new DOMException(`Failed to execute 'insertAdjacentHTML' on 'Element': The value provided (${position}) is not one of 'beforeBegin', 'afterBegin', 'beforeEnd', or 'afterEnd'.`);
@@ -304,19 +304,19 @@ module.exports = class Element extends Node {
     switch (position) {
       case "beforebegin":
         this.$elm.before(element.$elm);
-        if (this.parentElement) this.parentElement.dispatchEvent(new MutationEvent("childList"));
+        if (this.parentElement) this.parentElement.dispatchEvent(new ChildListMutationEvent());
         break;
       case "afterbegin":
         this.$elm.prepend(element.$elm);
-        this.dispatchEvent(new MutationEvent("childList"));
+        this.dispatchEvent(new ChildListMutationEvent());
         break;
       case "beforeend":
         this.$elm.append(element.$elm);
-        this.dispatchEvent(new MutationEvent("childList"));
+        this.dispatchEvent(new ChildListMutationEvent());
         break;
       case "afterend":
         this.$elm.after(element.$elm);
-        if (this.parentElement) this.parentElement.dispatchEvent(new MutationEvent("childList"));
+        if (this.parentElement) this.parentElement.dispatchEvent(new ChildListMutationEvent());
         break;
       default:
         throw new DOMException(`Failed to execute 'insertAdjacentElement' on 'Element': The value provided (${position}) is not one of 'beforeBegin', 'afterBegin', 'beforeEnd', or 'afterEnd'.`);
@@ -334,13 +334,13 @@ module.exports = class Element extends Node {
         throw new DOMException("Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.");
       }
       newNode.$elm.insertBefore(referenceNode.$elm);
-      this.dispatchEvent(new MutationEvent("childList"));
+      this.dispatchEvent(new ChildListMutationEvent());
       return newNode;
     }
 
     if (newNode.textContent) {
       referenceNode.$elm.before(newNode.textContent);
-      this.dispatchEvent(new MutationEvent("childList"));
+      this.dispatchEvent(new ChildListMutationEvent());
       return newNode;
     }
   }
@@ -354,7 +354,7 @@ module.exports = class Element extends Node {
   remove() {
     const parentElement = this.parentElement;
     this.$elm.remove();
-    parentElement?.dispatchEvent(new MutationEvent("childList"));
+    parentElement?.dispatchEvent(new ChildListMutationEvent());
   }
   replaceChildren() {
     this.$elm.contents().remove();
@@ -362,7 +362,7 @@ module.exports = class Element extends Node {
       this.appendChild(child);
     }
     if (arguments.length === 0) {
-      this.dispatchEvent(new MutationEvent("childList"));
+      this.dispatchEvent(new ChildListMutationEvent());
     }
   }
   replaceWith() {
@@ -379,7 +379,7 @@ module.exports = class Element extends Node {
   removeAttribute(name) {
     if (!this.hasAttribute(name)) return;
     this.$elm.removeAttr(name);
-    this.dispatchEvent(new MutationEvent("attributes", { attributeName: name }));
+    this.dispatchEvent(new AttributesMutationEvent({ attributeName: name }));
   }
   requestFullscreen() {
     const fullscreenchangeEvent = new Event("fullscreenchange", { bubbles: true });

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -136,8 +136,9 @@ module.exports = class Element extends Node {
     return this.ownerDocument.$.html(this.$elm);
   }
   set outerHTML(value) {
+    const { parentElement } = this;
     this.$elm.replaceWith(this.ownerDocument.$(value));
-    this._registerMutation("childList");
+    parentElement._registerMutation("childList");
   }
   get src() {
     let rel = this.getAttribute("src");

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -117,14 +117,14 @@ module.exports = class Element extends Node {
   }
   set innerHTML(value) {
     this.$elm.html(value);
-    this.dispatchEvent(new ChildListMutationEvent());
+    this._emitter.emit("ChildListMutationEvent", this);
   }
   get textContent() {
     return this.$elm.text() || "";
   }
   set textContent(value) {
     const response = this.$elm.text(value);
-    this.dispatchEvent(new ChildListMutationEvent());
+    this._emitter.emit("ChildListMutationEvent", this);
     return response;
   }
   get innerText() {
@@ -138,7 +138,7 @@ module.exports = class Element extends Node {
   }
   set outerHTML(value) {
     this.$elm.replaceWith(this.ownerDocument.$(value));
-    this.dispatchEvent(new ChildListMutationEvent());
+    this._emitter.emit("ChildListMutationEvent", this);
   }
   get src() {
     let rel = this.getAttribute("src");
@@ -239,7 +239,7 @@ module.exports = class Element extends Node {
         childElement._runScript();
       }
 
-      this.dispatchEvent(new ChildListMutationEvent());
+      this._emitter.emit("ChildListMutationEvent", this);
     } else if (childElement.textContent) {
       this.insertAdjacentHTML("beforeend", childElement.textContent);
     }
@@ -259,7 +259,7 @@ module.exports = class Element extends Node {
   }
   setAttribute(name, val) {
     this.$elm.attr(name, val);
-    this.dispatchEvent(new AttributesMutationEvent({ attributeName: name }));
+    this._emitter.emit("AttributesMutationEvent", { attributeName: name }, this);
   }
   getBoundingClientRect() {
     return this[rectsSymbol];
@@ -282,19 +282,19 @@ module.exports = class Element extends Node {
     switch (position.toLowerCase()) {
       case "beforebegin":
         this.$elm.before(markup);
-        if (this.parentElement) this.parentElement.dispatchEvent(new ChildListMutationEvent());
+        if (this.parentElement) this.parentElement._emitter.emit("ChildListMutationEvent", this.parentElement);
         break;
       case "afterbegin":
         this.$elm.prepend(markup);
-        this.dispatchEvent(new ChildListMutationEvent());
+        this._emitter.emit("ChildListMutationEvent", this);
         break;
       case "beforeend":
         this.$elm.append(markup);
-        this.dispatchEvent(new ChildListMutationEvent());
+        this._emitter.emit("ChildListMutationEvent", this);
         break;
       case "afterend":
         this.$elm.after(markup);
-        if (this.parentElement) this.parentElement.dispatchEvent(new ChildListMutationEvent());
+        if (this.parentElement) this.parentElement._emitter.emit("ChildListMutationEvent", this.parentElement);
         break;
       default:
         throw new DOMException(`Failed to execute 'insertAdjacentHTML' on 'Element': The value provided (${position}) is not one of 'beforeBegin', 'afterBegin', 'beforeEnd', or 'afterEnd'.`);
@@ -304,19 +304,19 @@ module.exports = class Element extends Node {
     switch (position) {
       case "beforebegin":
         this.$elm.before(element.$elm);
-        if (this.parentElement) this.parentElement.dispatchEvent(new ChildListMutationEvent());
+        if (this.parentElement) this.parentElement._emitter.emit("ChildListMutationEvent", this.parentElement);
         break;
       case "afterbegin":
         this.$elm.prepend(element.$elm);
-        this.dispatchEvent(new ChildListMutationEvent());
+        this._emitter.emit("ChildListMutationEvent", this);
         break;
       case "beforeend":
         this.$elm.append(element.$elm);
-        this.dispatchEvent(new ChildListMutationEvent());
+        this._emitter.emit("ChildListMutationEvent", this);
         break;
       case "afterend":
         this.$elm.after(element.$elm);
-        if (this.parentElement) this.parentElement.dispatchEvent(new ChildListMutationEvent());
+        if (this.parentElement) this.parentElement._emitter.emit("ChildListMutationEvent", this.parentElement);
         break;
       default:
         throw new DOMException(`Failed to execute 'insertAdjacentElement' on 'Element': The value provided (${position}) is not one of 'beforeBegin', 'afterBegin', 'beforeEnd', or 'afterEnd'.`);
@@ -334,13 +334,13 @@ module.exports = class Element extends Node {
         throw new DOMException("Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.");
       }
       newNode.$elm.insertBefore(referenceNode.$elm);
-      this.dispatchEvent(new ChildListMutationEvent());
+      this._emitter.emit("ChildListMutationEvent", this);
       return newNode;
     }
 
     if (newNode.textContent) {
       referenceNode.$elm.before(newNode.textContent);
-      this.dispatchEvent(new ChildListMutationEvent());
+      this._emitter.emit("ChildListMutationEvent", this);
       return newNode;
     }
   }
@@ -354,7 +354,7 @@ module.exports = class Element extends Node {
   remove() {
     const parentElement = this.parentElement;
     this.$elm.remove();
-    parentElement?.dispatchEvent(new ChildListMutationEvent());
+    parentElement?._emitter.emit("ChildListMutationEvent", parentElement);
   }
   replaceChildren() {
     this.$elm.contents().remove();
@@ -362,7 +362,7 @@ module.exports = class Element extends Node {
       this.appendChild(child);
     }
     if (arguments.length === 0) {
-      this.dispatchEvent(new ChildListMutationEvent());
+      this._emitter.emit("ChildListMutationEvent", this);
     }
   }
   replaceWith() {
@@ -379,7 +379,7 @@ module.exports = class Element extends Node {
   removeAttribute(name) {
     if (!this.hasAttribute(name)) return;
     this.$elm.removeAttr(name);
-    this.dispatchEvent(new AttributesMutationEvent({ attributeName: name }));
+    this._emitter.emit("AttributesMutationEvent", { attributeName: name }, this);
   }
   requestFullscreen() {
     const fullscreenchangeEvent = new Event("fullscreenchange", { bubbles: true });

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -12,7 +12,7 @@ const HTMLCollection = require("./HTMLCollection.js");
 const Node = require("./Node.js");
 const NodeList = require("./NodeList.js");
 const eventnames = require("./eventnames.js");
-const { AttributeChangeEvent } = require("./MutationObserver.js");
+const { AttributeChangeEvent, InsertEvent } = require("./MutationObserver.js");
 
 const classListSymbol = Symbol.for("classList");
 const rectsSymbol = Symbol.for("rects");
@@ -47,12 +47,6 @@ module.exports = class Element extends Node {
         this[name] = vm.compileFunction(value, [ "event" ], { contextExtensions });
       }
     }
-
-    this._emitter.on("_insert", (...args) => {
-      if (this.parentElement) {
-        this.parentElement._emitter.emit("_insert", ...args);
-      }
-    });
   }
   get attributes() {
     const attr = this.$elm.attr();
@@ -245,7 +239,7 @@ module.exports = class Element extends Node {
         childElement._runScript();
       }
 
-      this._emitter.emit("_insert");
+      this.dispatchEvent(new InsertEvent());
     } else if (childElement.textContent) {
       this.insertAdjacentHTML("beforeend", childElement.textContent);
     }

--- a/lib/EventTarget.js
+++ b/lib/EventTarget.js
@@ -1,26 +1,17 @@
 "use strict";
 
 const { EventEmitter } = require("events");
+const { Mutation } = require("./MutationObserver");
 
 const kEmitter = Symbol.for("emitter");
 const kListeners = Symbol.for("listeners");
 
 module.exports = class EventTarget {
   constructor() {
-    const self = this;
+    this[kListeners] = [];
     const emitter = this[kEmitter] = new EventEmitter();
     emitter.setMaxListeners(0);
-    this[kListeners] = [];
-    emitter.on("AttributesMutationEvent", onAttributesMutation);
-    emitter.on("ChildListMutationEvent", onChildListMutation);
-
-    function onAttributesMutation(mutation, ...path) {
-      self.parentElement?._emitter.emit("AttributesMutationEvent", mutation, self.parentElement, ...path);
-    }
-
-    function onChildListMutation(...path) {
-      self.parentElement?._emitter.emit("ChildListMutationEvent", self.parentElement, ...path);
-    }
+    emitter.on("_mutation", this._onMutation.bind(this));
   }
   get _emitter() {
     return this[kEmitter];
@@ -80,6 +71,13 @@ module.exports = class EventTarget {
         && listener[1] === config[1]
         && listener[2] === config[2];
     });
+  }
+  _registerMutation(type, details) {
+    const mutation = new Mutation(type, this, details);
+    this[kEmitter].emit("_mutation", mutation, this);
+  }
+  _onMutation(mutation) {
+    this.parentElement?._emitter.emit("_mutation", mutation, this.parentElement);
   }
 };
 

--- a/lib/EventTarget.js
+++ b/lib/EventTarget.js
@@ -7,9 +7,20 @@ const kListeners = Symbol.for("listeners");
 
 module.exports = class EventTarget {
   constructor() {
+    const self = this;
     const emitter = this[kEmitter] = new EventEmitter();
     emitter.setMaxListeners(0);
     this[kListeners] = [];
+    emitter.on("AttributesMutationEvent", onAttributesMutation);
+    emitter.on("ChildListMutationEvent", onChildListMutation);
+
+    function onAttributesMutation(mutation, ...path) {
+      self.parentElement?._emitter.emit("AttributesMutationEvent", mutation, self.parentElement, ...path);
+    }
+
+    function onChildListMutation(...path) {
+      self.parentElement?._emitter.emit("ChildListMutationEvent", self.parentElement, ...path);
+    }
   }
   get _emitter() {
     return this[kEmitter];

--- a/lib/HTMLCollection.js
+++ b/lib/HTMLCollection.js
@@ -3,8 +3,8 @@
 const NodeList = require("./NodeList.js");
 
 module.exports = class HTMLCollection extends NodeList {
-  constructor(parentElement, selector, options = { attributes: true, childList: true, subtree: true }) {
-    super(parentElement, selector, options);
+  constructor(parentElement, selector, options = { attributes: true, childList: true, subtree: true }, debug) {
+    super(parentElement, selector, options, debug);
 
     Object.defineProperties(this, {
       item: { enumerable: true },

--- a/lib/HTMLCollection.js
+++ b/lib/HTMLCollection.js
@@ -3,8 +3,8 @@
 const NodeList = require("./NodeList.js");
 
 module.exports = class HTMLCollection extends NodeList {
-  constructor(parentElement, selector, options = { attributes: true }) {
-    super(parentElement, selector, { ...options });
+  constructor(parentElement, selector, options = { attributes: true, childList: true, subtree: true }) {
+    super(parentElement, selector, options);
 
     Object.defineProperties(this, {
       item: { enumerable: true },

--- a/lib/HTMLCollection.js
+++ b/lib/HTMLCollection.js
@@ -3,8 +3,8 @@
 const NodeList = require("./NodeList.js");
 
 module.exports = class HTMLCollection extends NodeList {
-  constructor(parentElement, selector, options = { attributes: true, childList: true, subtree: true }, debug) {
-    super(parentElement, selector, options, debug);
+  constructor(parentElement, selector, options = { attributes: true, childList: true, subtree: true }) {
+    super(parentElement, selector, options);
 
     Object.defineProperties(this, {
       item: { enumerable: true },

--- a/lib/HTMLOptionElement.js
+++ b/lib/HTMLOptionElement.js
@@ -22,7 +22,6 @@ module.exports = class HTMLOptionElement extends HTMLElement {
     }
 
     if (value !== oldValue) {
-      console.log("set selected", value);
       this.dispatchEvent(new AttributesMutationEvent({ internal: true }));
       if (parent) parent.dispatchEvent(new Event("change", { bubbles: true }));
     }

--- a/lib/HTMLOptionElement.js
+++ b/lib/HTMLOptionElement.js
@@ -21,7 +21,6 @@ module.exports = class HTMLOptionElement extends HTMLElement {
     }
 
     if (value !== oldValue) {
-      this._emitter.emit("_insert");
       if (parent) parent.dispatchEvent(new Event("change", { bubbles: true }));
     }
 

--- a/lib/HTMLOptionElement.js
+++ b/lib/HTMLOptionElement.js
@@ -2,6 +2,7 @@
 
 const HTMLElement = require("./HTMLElement.js");
 const { Event } = require("./Events.js");
+const { MutationEvent } = require("./MutationObserver.js");
 
 module.exports = class HTMLOptionElement extends HTMLElement {
   get selected() {
@@ -21,6 +22,7 @@ module.exports = class HTMLOptionElement extends HTMLElement {
     }
 
     if (value !== oldValue) {
+      this.dispatchEvent(new MutationEvent("attributes", { internal: true }));
       if (parent) parent.dispatchEvent(new Event("change", { bubbles: true }));
     }
 

--- a/lib/HTMLOptionElement.js
+++ b/lib/HTMLOptionElement.js
@@ -22,7 +22,7 @@ module.exports = class HTMLOptionElement extends HTMLElement {
     }
 
     if (value !== oldValue) {
-      this.dispatchEvent(new AttributesMutationEvent({ internal: true }));
+      this._emitter.emit("AttributesMutationEvent", { internal: true }, this);
       if (parent) parent.dispatchEvent(new Event("change", { bubbles: true }));
     }
 

--- a/lib/HTMLOptionElement.js
+++ b/lib/HTMLOptionElement.js
@@ -2,7 +2,6 @@
 
 const HTMLElement = require("./HTMLElement.js");
 const { Event } = require("./Events.js");
-const { AttributesMutationEvent } = require("./MutationObserver.js");
 
 module.exports = class HTMLOptionElement extends HTMLElement {
   get selected() {
@@ -22,7 +21,7 @@ module.exports = class HTMLOptionElement extends HTMLElement {
     }
 
     if (value !== oldValue) {
-      this._emitter.emit("AttributesMutationEvent", { internal: true }, this);
+      this._registerMutation("attributes", { internal: true });
       if (parent) parent.dispatchEvent(new Event("change", { bubbles: true }));
     }
 

--- a/lib/HTMLOptionElement.js
+++ b/lib/HTMLOptionElement.js
@@ -2,7 +2,7 @@
 
 const HTMLElement = require("./HTMLElement.js");
 const { Event } = require("./Events.js");
-const { MutationEvent } = require("./MutationObserver.js");
+const { AttributesMutationEvent } = require("./MutationObserver.js");
 
 module.exports = class HTMLOptionElement extends HTMLElement {
   get selected() {
@@ -22,7 +22,7 @@ module.exports = class HTMLOptionElement extends HTMLElement {
     }
 
     if (value !== oldValue) {
-      this.dispatchEvent(new MutationEvent("attributes", { internal: true }));
+      this.dispatchEvent(new AttributesMutationEvent({ internal: true }));
       if (parent) parent.dispatchEvent(new Event("change", { bubbles: true }));
     }
 

--- a/lib/HTMLOptionElement.js
+++ b/lib/HTMLOptionElement.js
@@ -22,6 +22,7 @@ module.exports = class HTMLOptionElement extends HTMLElement {
     }
 
     if (value !== oldValue) {
+      console.log("set selected", value);
       this.dispatchEvent(new AttributesMutationEvent({ internal: true }));
       if (parent) parent.dispatchEvent(new Event("change", { bubbles: true }));
     }

--- a/lib/HTMLOptionsCollection.js
+++ b/lib/HTMLOptionsCollection.js
@@ -7,7 +7,12 @@ const kLiveList = Symbol.for("liveList");
 
 module.exports = class HTMLOptionCollection extends NodeList {
   constructor(parentElement) {
-    super(parentElement, "> option", { attributes: false });
+    super(parentElement, "> option", {
+      attributes: true,
+      childList: true,
+      subtree: true,
+      _internal: true,
+    });
     if (!this.length) this[kSelectedIndex] = -1;
     else this[kSelectedIndex] = parentElement.multiple ? -1 : 0;
 

--- a/lib/HTMLOptionsCollection.js
+++ b/lib/HTMLOptionsCollection.js
@@ -7,12 +7,7 @@ const kLiveList = Symbol.for("liveList");
 
 module.exports = class HTMLOptionCollection extends NodeList {
   constructor(parentElement) {
-    super(parentElement, "> option", {
-      attributes: true,
-      childList: true,
-      subtree: true,
-      _internal: true,
-    });
+    super(parentElement, "> option", { childList: true });
     if (!this.length) this[kSelectedIndex] = -1;
     else this[kSelectedIndex] = parentElement.multiple ? -1 : 0;
 

--- a/lib/HTMLScriptElement.js
+++ b/lib/HTMLScriptElement.js
@@ -3,6 +3,7 @@
 const vm = require("vm");
 
 const HTMLElement = require("./HTMLElement.js");
+const { MutationEvent } = require("./MutationObserver.js");
 
 module.exports = class HTMLScriptElement extends HTMLElement {
   get textContent() {
@@ -10,7 +11,7 @@ module.exports = class HTMLScriptElement extends HTMLElement {
   }
   set textContent(value) {
     const response = this.$elm.html(value);
-    this._emitter.emit("_insert");
+    this.dispatchEvent(new MutationEvent("childList"));
     return response;
   }
   _runScript() {

--- a/lib/HTMLScriptElement.js
+++ b/lib/HTMLScriptElement.js
@@ -11,7 +11,7 @@ module.exports = class HTMLScriptElement extends HTMLElement {
   }
   set textContent(value) {
     const response = this.$elm.html(value);
-    this.dispatchEvent(new ChildListMutationEvent());
+    this._emitter.emit("ChildListMutationEvent", this);
     return response;
   }
   _runScript() {

--- a/lib/HTMLScriptElement.js
+++ b/lib/HTMLScriptElement.js
@@ -3,7 +3,6 @@
 const vm = require("vm");
 
 const HTMLElement = require("./HTMLElement.js");
-const { ChildListMutationEvent } = require("./MutationObserver.js");
 
 module.exports = class HTMLScriptElement extends HTMLElement {
   get textContent() {
@@ -11,7 +10,7 @@ module.exports = class HTMLScriptElement extends HTMLElement {
   }
   set textContent(value) {
     const response = this.$elm.html(value);
-    this._emitter.emit("ChildListMutationEvent", this);
+    this._registerMutation("childList");
     return response;
   }
   _runScript() {

--- a/lib/HTMLScriptElement.js
+++ b/lib/HTMLScriptElement.js
@@ -3,7 +3,7 @@
 const vm = require("vm");
 
 const HTMLElement = require("./HTMLElement.js");
-const { MutationEvent } = require("./MutationObserver.js");
+const { ChildListMutationEvent } = require("./MutationObserver.js");
 
 module.exports = class HTMLScriptElement extends HTMLElement {
   get textContent() {
@@ -11,7 +11,7 @@ module.exports = class HTMLScriptElement extends HTMLElement {
   }
   set textContent(value) {
     const response = this.$elm.html(value);
-    this.dispatchEvent(new MutationEvent("childList"));
+    this.dispatchEvent(new ChildListMutationEvent());
     return response;
   }
   _runScript() {

--- a/lib/HTMLSelectElement.js
+++ b/lib/HTMLSelectElement.js
@@ -20,6 +20,7 @@ module.exports = class HTMLSelectElement extends HTMLElement {
     this[kOptions] = new HtmlOptionCollection(this);
     this[kSelectedOptions] = new HTMLCollection(this, "> option", {
       childList: true,
+      subtree: true,
       filter(_, $elm) {
         return $elm.prop("selected");
       },

--- a/lib/HTMLSelectElement.js
+++ b/lib/HTMLSelectElement.js
@@ -19,8 +19,10 @@ module.exports = class HTMLSelectElement extends HTMLElement {
     this[kValidity] = new ValidityState(this);
     this[kOptions] = new HtmlOptionCollection(this);
     this[kSelectedOptions] = new HTMLCollection(this, "> option", {
+      attributes: true,
       childList: true,
       subtree: true,
+      _internal: true,
       filter(_, $elm) {
         return $elm.prop("selected");
       },

--- a/lib/MutationObserver.js
+++ b/lib/MutationObserver.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { Event } = require("./Events");
+const assert = require("node:assert/strict");
 
 const optionsByNodeSymbol = Symbol.for("optionsByNode");
 const callbackSymbol = Symbol.for("callback");
@@ -10,82 +10,36 @@ class MutationObserver {
   constructor(callback) {
     this[callbackSymbol] = callback;
     this[optionsByNodeSymbol] = new Map();
-    this._onAttributesMutationEvent = this._onAttributesMutationEvent.bind(this);
-    this._onChildListMutationEvent = this._onChildListMutationEvent.bind(this);
     this._onMutation = this._onMutation.bind(this);
   }
   observe(targetNode, options) {
     this[optionsByNodeSymbol].set(targetNode, options);
-
-    if (options.attributes) {
-      targetNode._emitter.on("AttributesMutationEvent", this._onAttributesMutationEvent);
-    }
-    if (options.childList) {
-      targetNode._emitter.on("ChildListMutationEvent", this._onChildListMutationEvent);
-    }
+    targetNode._emitter.on("_mutation", this._onMutation);
   }
   disconnect() {
     for (const node of this[optionsByNodeSymbol].keys()) {
-      node._emitter.off("AttributesMutationEvent", this._onAttributesMutationEvent);
-      node._emitter.off("ChildListMutationEvent", this._onChildListMutationEvent);
+      node._emitter.off("_mutation", this._onMutation);
     }
   }
-  _onAttributesMutationEvent(mutation, ...path) {
-    this._onMutation({
-      currentTarget: path[0],
-      target: path[path.length - 1],
-      mutation: {
-        ...mutation,
-        type: "attributes",
-        target: path[path.length - 1],
-      },
-    });
-  }
-  _onChildListMutationEvent(...path) {
-    this._onMutation({
-      currentTarget: path[0],
-      target: path[path.length - 1],
-      mutation: {
-        type: "childList",
-        target: path[path.length - 1],
-      },
-    });
-  }
-  _onMutation(event) {
-    const options = this[optionsByNodeSymbol].get(event.currentTarget);
-    if (!options._internal && event.mutation.internal) return;
-    if (!options.subtree && event.currentTarget !== event.target) return;
+  _onMutation(mutation, currentTarget) {
+    const options = this[optionsByNodeSymbol].get(currentTarget);
+    if (!options[mutation.type]) return;
+    if (!options._internal && mutation.internal) return;
+    if (!options.subtree && currentTarget !== mutation.target) return;
 
-    return this[callbackSymbol].call(this, [ event.mutation ]);
+    return this[callbackSymbol].call(this, [ mutation ]);
   }
 }
 
-class MutationEvent extends Event {
-  constructor(type, mutation = {}) {
-    super(`_mutation:${type}`, { bubbles: true });
-    const event = this;
-    this.mutation = {
-      ...mutation,
+class Mutation {
+  constructor(type, target, details = {}) {
+    assert(mutationTypes.includes(type), `Unknown mutation type: ${type}`);
+    Object.assign(this, details, {
       type,
-      get target() {
-        return event.target;
-      },
-    };
-  }
-}
-
-class AttributesMutationEvent extends MutationEvent {
-  constructor(mutation) {
-    super("attributes", mutation);
-  }
-}
-
-class ChildListMutationEvent extends MutationEvent {
-  constructor(mutation) {
-    super("childList", mutation);
+      target,
+    });
   }
 }
 
 module.exports = MutationObserver;
-module.exports.AttributesMutationEvent = AttributesMutationEvent;
-module.exports.ChildListMutationEvent = ChildListMutationEvent;
+module.exports.Mutation = Mutation;

--- a/lib/MutationObserver.js
+++ b/lib/MutationObserver.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const assert = require("assert/strict");
 const { Event } = require("./Events");
 
 const optionsByNodeSymbol = Symbol.for("optionsByNode");
@@ -38,13 +37,12 @@ class MutationObserver {
 }
 
 class MutationEvent extends Event {
-  constructor(type, meta = {}) {
-    assert(mutationTypes.includes(type), `Unexpected mutation type "${type}"`);
+  constructor(type, mutation = {}) {
     super(`_mutation:${type}`, { bubbles: true });
     const event = this;
     this.mutation = {
+      ...mutation,
       type,
-      ...meta,
       get target() {
         return event.target;
       },
@@ -52,5 +50,18 @@ class MutationEvent extends Event {
   }
 }
 
+class AttributesMutationEvent extends MutationEvent {
+  constructor(mutation) {
+    super("attributes", mutation);
+  }
+}
+
+class ChildListMutationEvent extends MutationEvent {
+  constructor(mutation) {
+    super("childList", mutation);
+  }
+}
+
 module.exports = MutationObserver;
-module.exports.MutationEvent = MutationEvent;
+module.exports.AttributesMutationEvent = AttributesMutationEvent;
+module.exports.ChildListMutationEvent = ChildListMutationEvent;

--- a/lib/MutationObserver.js
+++ b/lib/MutationObserver.js
@@ -2,7 +2,6 @@
 
 const { Event } = require("./Events");
 
-const emitterSymbol = Symbol.for("emitter");
 const optionsByNodeSymbol = Symbol.for("optionsByNode");
 const callbackSymbol = Symbol.for("callback");
 
@@ -11,36 +10,30 @@ class MutationObserver {
     this[callbackSymbol] = callback;
     this[optionsByNodeSymbol] = new Map();
     this._onMutation = this._onMutation.bind(this);
-    this._onAttributeChange = this._onAttributeChange.bind(this);
   }
   observe(targetNode, options) {
     this[optionsByNodeSymbol].set(targetNode, options);
 
     if (options.attributes) {
-      targetNode.addEventListener("_attributeChange", this._onAttributeChange);
+      targetNode.addEventListener("_attributeChange", this._onMutation);
     }
     if (options.childList) {
-      targetNode[emitterSymbol].on("_insert", this._onMutation);
+      targetNode.addEventListener("_insert", this._onMutation);
     }
   }
   disconnect() {
     for (const node of this[optionsByNodeSymbol].keys()) {
-      node[emitterSymbol].removeListener("_insert", this._onMutation);
-      node.removeEventListener("_attributeChange", this._onAttributeChange);
+      node.removeEventListener("_attributeChange", this._onMutation);
+      node.removeEventListener("_insert", this._onMutation);
     }
   }
-  _onMutation() {
-    return this[callbackSymbol].call(this, [
-      mutationRecord("childList"),
-    ]);
-  }
-  _onAttributeChange(event) {
+  _onMutation(event) {
     const { currentTarget, target, mutation } = event;
     const { subtree } = this[optionsByNodeSymbol].get(currentTarget);
     if (!subtree && currentTarget !== target) return;
 
     return this[callbackSymbol].call(this, [
-      mutationRecord("attributes", mutation),
+      mutation,
     ]);
   }
 }
@@ -48,13 +41,23 @@ class MutationObserver {
 class AttributeChangeEvent extends Event {
   constructor(mutation) {
     super("_attributeChange", { bubbles: true });
-    this.mutation = mutation;
+    this.mutation = {
+      ...mutation,
+      type: "attributes",
+    };
+  }
+}
+
+class InsertEvent extends Event {
+  constructor(mutation) {
+    super("_insert", { bubbles: true });
+    this.mutation = {
+      ...mutation,
+      type: "childList",
+    };
   }
 }
 
 module.exports = MutationObserver;
 module.exports.AttributeChangeEvent = AttributeChangeEvent;
-
-function mutationRecord(type, mutation = {}) {
-  return { type, ...mutation };
-}
+module.exports.InsertEvent = InsertEvent;

--- a/lib/MutationObserver.js
+++ b/lib/MutationObserver.js
@@ -4,6 +4,7 @@ const { Event } = require("./Events");
 
 const optionsByNodeSymbol = Symbol.for("optionsByNode");
 const callbackSymbol = Symbol.for("callback");
+const mutationTypes = [ "attributes", "characterData", "childList" ];
 
 class MutationObserver {
   constructor(callback) {
@@ -14,17 +15,16 @@ class MutationObserver {
   observe(targetNode, options) {
     this[optionsByNodeSymbol].set(targetNode, options);
 
-    if (options.attributes) {
-      targetNode.addEventListener("_attributeChange", this._onMutation);
-    }
-    if (options.childList) {
-      targetNode.addEventListener("_insert", this._onMutation);
+    for (const mutationType of mutationTypes) {
+      if (!options[mutationType]) continue;
+      targetNode.addEventListener(`_mutation:${mutationType}`, this._onMutation);
     }
   }
   disconnect() {
     for (const node of this[optionsByNodeSymbol].keys()) {
-      node.removeEventListener("_attributeChange", this._onMutation);
-      node.removeEventListener("_insert", this._onMutation);
+      for (const mutationType of mutationTypes) {
+        node.removeEventListener(`_mutation:${mutationType}`, this._onMutation);
+      }
     }
   }
   _onMutation(event) {
@@ -38,26 +38,12 @@ class MutationObserver {
   }
 }
 
-class AttributeChangeEvent extends Event {
-  constructor(mutation) {
-    super("_attributeChange", { bubbles: true });
-    this.mutation = {
-      ...mutation,
-      type: "attributes",
-    };
-  }
-}
-
-class InsertEvent extends Event {
-  constructor(mutation) {
-    super("_insert", { bubbles: true });
-    this.mutation = {
-      ...mutation,
-      type: "childList",
-    };
+class MutationEvent extends Event {
+  constructor(type, meta = {}) {
+    super(`_mutation:${type}`, { bubbles: true });
+    this.mutation = { type, ...meta };
   }
 }
 
 module.exports = MutationObserver;
-module.exports.AttributeChangeEvent = AttributeChangeEvent;
-module.exports.InsertEvent = InsertEvent;
+module.exports.MutationEvent = MutationEvent;

--- a/lib/MutationObserver.js
+++ b/lib/MutationObserver.js
@@ -10,22 +10,46 @@ class MutationObserver {
   constructor(callback) {
     this[callbackSymbol] = callback;
     this[optionsByNodeSymbol] = new Map();
+    this._onAttributesMutationEvent = this._onAttributesMutationEvent.bind(this);
+    this._onChildListMutationEvent = this._onChildListMutationEvent.bind(this);
     this._onMutation = this._onMutation.bind(this);
   }
   observe(targetNode, options) {
     this[optionsByNodeSymbol].set(targetNode, options);
 
-    for (const mutationType of mutationTypes) {
-      if (!options[mutationType]) continue;
-      targetNode.addEventListener(`_mutation:${mutationType}`, this._onMutation);
+    if (options.attributes) {
+      targetNode._emitter.on("AttributesMutationEvent", this._onAttributesMutationEvent);
+    }
+    if (options.childList) {
+      targetNode._emitter.on("ChildListMutationEvent", this._onChildListMutationEvent);
     }
   }
   disconnect() {
     for (const node of this[optionsByNodeSymbol].keys()) {
-      for (const mutationType of mutationTypes) {
-        node.removeEventListener(`_mutation:${mutationType}`, this._onMutation);
-      }
+      node._emitter.off("AttributesMutationEvent", this._onAttributesMutationEvent);
+      node._emitter.off("ChildListMutationEvent", this._onChildListMutationEvent);
     }
+  }
+  _onAttributesMutationEvent(mutation, ...path) {
+    this._onMutation({
+      currentTarget: path[0],
+      target: path[path.length - 1],
+      mutation: {
+        ...mutation,
+        type: "attributes",
+        target: path[path.length - 1],
+      },
+    });
+  }
+  _onChildListMutationEvent(...path) {
+    this._onMutation({
+      currentTarget: path[0],
+      target: path[path.length - 1],
+      mutation: {
+        type: "childList",
+        target: path[path.length - 1],
+      },
+    });
   }
   _onMutation(event) {
     const options = this[optionsByNodeSymbol].get(event.currentTarget);

--- a/lib/MutationObserver.js
+++ b/lib/MutationObserver.js
@@ -41,7 +41,14 @@ class MutationObserver {
 class MutationEvent extends Event {
   constructor(type, meta = {}) {
     super(`_mutation:${type}`, { bubbles: true });
-    this.mutation = { type, ...meta };
+    const event = this;
+    this.mutation = {
+      type,
+      ...meta,
+      get target() {
+        return event.target;
+      },
+    };
   }
 }
 

--- a/lib/MutationObserver.js
+++ b/lib/MutationObserver.js
@@ -29,12 +29,9 @@ class MutationObserver {
   }
   _onMutation(event) {
     const options = this[optionsByNodeSymbol].get(event.currentTarget);
-    console.log("mutated", event.currentTarget.tagName, options);
-    console.log("mutation", event.mutation);
     if (!options._internal && event.mutation.internal) return;
     if (!options.subtree && event.currentTarget !== event.target) return;
 
-    console.log(12);
     return this[callbackSymbol].call(this, [ event.mutation ]);
   }
 }

--- a/lib/MutationObserver.js
+++ b/lib/MutationObserver.js
@@ -4,7 +4,7 @@ const { Event } = require("./Events");
 
 const optionsByNodeSymbol = Symbol.for("optionsByNode");
 const callbackSymbol = Symbol.for("callback");
-const mutationTypes = [ "attributes", "characterData", "childList" ];
+const mutationTypes = [ "attributes", "childList" ];
 
 class MutationObserver {
   constructor(callback) {

--- a/lib/MutationObserver.js
+++ b/lib/MutationObserver.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const assert = require("assert/strict");
 const { Event } = require("./Events");
 
 const optionsByNodeSymbol = Symbol.for("optionsByNode");
@@ -28,18 +29,17 @@ class MutationObserver {
     }
   }
   _onMutation(event) {
-    const { currentTarget, target, mutation } = event;
-    const { subtree } = this[optionsByNodeSymbol].get(currentTarget);
-    if (!subtree && currentTarget !== target) return;
+    const options = this[optionsByNodeSymbol].get(event.currentTarget);
+    if (!options._internal && event.mutation.internal) return;
+    if (!options.subtree && event.currentTarget !== event.target) return;
 
-    return this[callbackSymbol].call(this, [
-      mutation,
-    ]);
+    return this[callbackSymbol].call(this, [ event.mutation ]);
   }
 }
 
 class MutationEvent extends Event {
   constructor(type, meta = {}) {
+    assert(mutationTypes.includes(type), `Unexpected mutation type "${type}"`);
     super(`_mutation:${type}`, { bubbles: true });
     const event = this;
     this.mutation = {

--- a/lib/MutationObserver.js
+++ b/lib/MutationObserver.js
@@ -29,9 +29,12 @@ class MutationObserver {
   }
   _onMutation(event) {
     const options = this[optionsByNodeSymbol].get(event.currentTarget);
+    console.log("mutated", event.currentTarget.tagName, options);
+    console.log("mutation", event.mutation);
     if (!options._internal && event.mutation.internal) return;
     if (!options.subtree && event.currentTarget !== event.target) return;
 
+    console.log(12);
     return this[callbackSymbol].call(this, [ event.mutation ]);
   }
 }

--- a/lib/MutationObserver.js
+++ b/lib/MutationObserver.js
@@ -2,32 +2,41 @@
 
 const assert = require("node:assert/strict");
 
-const optionsByNodeSymbol = Symbol.for("optionsByNode");
+const optionsListByNodeSymbol = Symbol.for("optionsListByNode");
 const callbackSymbol = Symbol.for("callback");
 const mutationTypes = [ "attributes", "childList" ];
 
 class MutationObserver {
   constructor(callback) {
     this[callbackSymbol] = callback;
-    this[optionsByNodeSymbol] = new Map();
+    this[optionsListByNodeSymbol] = new Map();
     this._onMutation = this._onMutation.bind(this);
   }
   observe(targetNode, options) {
-    this[optionsByNodeSymbol].set(targetNode, options);
+    const optionsListByNode = this[optionsListByNodeSymbol];
+    if (optionsListByNode.has(targetNode)) {
+      optionsListByNode.get(targetNode).push(options);
+      return;
+    }
+
+    optionsListByNode.set(targetNode, [ options ]);
     targetNode._emitter.on("_mutation", this._onMutation);
   }
   disconnect() {
-    for (const node of this[optionsByNodeSymbol].keys()) {
+    for (const node of this[optionsListByNodeSymbol].keys()) {
       node._emitter.off("_mutation", this._onMutation);
     }
+
+    this[optionsListByNodeSymbol].clear();
   }
   _onMutation(mutation, currentTarget) {
-    const options = this[optionsByNodeSymbol].get(currentTarget);
-    if (!options[mutation.type]) return;
-    if (!options._internal && mutation.internal) return;
-    if (!options.subtree && currentTarget !== mutation.target) return;
+    for (const options of this[optionsListByNodeSymbol].get(currentTarget)) {
+      if (!options[mutation.type]) continue;
+      if (!options._internal && mutation.internal) continue;
+      if (!options.subtree && currentTarget !== mutation.target) continue;
 
-    return this[callbackSymbol].call(this, [ mutation ]);
+      this[callbackSymbol].call(this, [ mutation ]);
+    }
   }
 }
 

--- a/lib/MutationObserver.js
+++ b/lib/MutationObserver.js
@@ -1,39 +1,60 @@
 "use strict";
 
+const { Event } = require("./Events");
+
 const emitterSymbol = Symbol.for("emitter");
-const nodeSymbol = Symbol.for("node");
+const optionsByNodeSymbol = Symbol.for("optionsByNode");
 const callbackSymbol = Symbol.for("callback");
 
-module.exports = class MutationObserver {
+class MutationObserver {
   constructor(callback) {
     this[callbackSymbol] = callback;
+    this[optionsByNodeSymbol] = new Map();
     this._onMutation = this._onMutation.bind(this);
     this._onAttributeChange = this._onAttributeChange.bind(this);
   }
   observe(targetNode, options) {
-    this[nodeSymbol] = targetNode;
+    this[optionsByNodeSymbol].set(targetNode, options);
+
+    if (options.attributes) {
+      targetNode.addEventListener("_attributeChange", this._onAttributeChange);
+    }
     if (options.childList) {
       targetNode[emitterSymbol].on("_insert", this._onMutation);
     }
-    if (options.attributes) {
-      targetNode[emitterSymbol].on("_attributeChange", this._onAttributeChange);
-    }
   }
   disconnect() {
-    const node = this[nodeSymbol];
-    if (!node) return;
-    this[nodeSymbol] = undefined;
-    node[emitterSymbol].removeListener("_insert", this._onMutation);
-    node[emitterSymbol].removeListener("_attributeChange", this._onAttributeChange);
+    for (const node of this[optionsByNodeSymbol].keys()) {
+      node[emitterSymbol].removeListener("_insert", this._onMutation);
+      node.removeEventListener("_attributeChange", this._onAttributeChange);
+    }
   }
   _onMutation() {
-    return this[callbackSymbol].call(this, [ mutationRecord("childList") ]);
+    return this[callbackSymbol].call(this, [
+      mutationRecord("childList"),
+    ]);
   }
-  _onAttributeChange(attributeName, target) {
-    return this[callbackSymbol].call(this, [ mutationRecord("attributes", { attributeName, target }) ]);
-  }
-};
+  _onAttributeChange(event) {
+    const { currentTarget, target, mutation } = event;
+    const { subtree } = this[optionsByNodeSymbol].get(currentTarget);
+    if (!subtree && currentTarget !== target) return;
 
-function mutationRecord(type, record = {}) {
-  return { type, ...record };
+    return this[callbackSymbol].call(this, [
+      mutationRecord("attributes", mutation),
+    ]);
+  }
+}
+
+class AttributeChangeEvent extends Event {
+  constructor(mutation) {
+    super("_attributeChange", { bubbles: true });
+    this.mutation = mutation;
+  }
+}
+
+module.exports = MutationObserver;
+module.exports.AttributeChangeEvent = AttributeChangeEvent;
+
+function mutationRecord(type, mutation = {}) {
+  return { type, ...mutation };
 }

--- a/lib/Node.js
+++ b/lib/Node.js
@@ -3,7 +3,7 @@
 const nodeTypes = require("./nodeTypes.js");
 const NodeList = require("./NodeList.js");
 const EventTarget = require("./EventTarget.js");
-const { MutationEvent } = require("./MutationObserver.js");
+const { ChildListMutationEvent } = require("./MutationObserver.js");
 
 const kDocument = Symbol.for("document");
 const kElm = Symbol.for("$elm");
@@ -140,7 +140,7 @@ module.exports = class Node extends EventTarget {
     }
 
     child.$elm.remove();
-    this.dispatchEvent(new MutationEvent("childList"));
+    this.dispatchEvent(new ChildListMutationEvent());
     return child;
   }
   replaceChild(newChild, oldChild) {
@@ -156,7 +156,7 @@ module.exports = class Node extends EventTarget {
 
     oldChild.$elm.replaceWith(newChild.nodeType === nodeTypes.TEXT_NODE ? newChild.textContent : newChild.outerHTML);
 
-    this.dispatchEvent(new MutationEvent("childList"));
+    this.dispatchEvent(new ChildListMutationEvent());
     return oldChild;
   }
   _getElement($ref) {

--- a/lib/Node.js
+++ b/lib/Node.js
@@ -3,6 +3,7 @@
 const nodeTypes = require("./nodeTypes.js");
 const NodeList = require("./NodeList.js");
 const EventTarget = require("./EventTarget.js");
+const { MutationEvent } = require("./MutationObserver.js");
 
 const kDocument = Symbol.for("document");
 const kElm = Symbol.for("$elm");
@@ -139,7 +140,7 @@ module.exports = class Node extends EventTarget {
     }
 
     child.$elm.remove();
-    this._emitter.emit("_insert");
+    this.dispatchEvent(new MutationEvent("childList"));
     return child;
   }
   replaceChild(newChild, oldChild) {

--- a/lib/Node.js
+++ b/lib/Node.js
@@ -156,7 +156,7 @@ module.exports = class Node extends EventTarget {
 
     oldChild.$elm.replaceWith(newChild.nodeType === nodeTypes.TEXT_NODE ? newChild.textContent : newChild.outerHTML);
 
-    this._emitter.emit("_insert");
+    this.dispatchEvent(new MutationEvent("childList"));
     return oldChild;
   }
   _getElement($ref) {

--- a/lib/Node.js
+++ b/lib/Node.js
@@ -3,7 +3,6 @@
 const nodeTypes = require("./nodeTypes.js");
 const NodeList = require("./NodeList.js");
 const EventTarget = require("./EventTarget.js");
-const { ChildListMutationEvent } = require("./MutationObserver.js");
 
 const kDocument = Symbol.for("document");
 const kElm = Symbol.for("$elm");
@@ -140,7 +139,7 @@ module.exports = class Node extends EventTarget {
     }
 
     child.$elm.remove();
-    this._emitter.emit("ChildListMutationEvent", this);
+    this._registerMutation("childList");
     return child;
   }
   replaceChild(newChild, oldChild) {
@@ -156,7 +155,7 @@ module.exports = class Node extends EventTarget {
 
     oldChild.$elm.replaceWith(newChild.nodeType === nodeTypes.TEXT_NODE ? newChild.textContent : newChild.outerHTML);
 
-    this._emitter.emit("ChildListMutationEvent", this);
+    this._registerMutation("childList");
     return oldChild;
   }
   _getElement($ref) {

--- a/lib/Node.js
+++ b/lib/Node.js
@@ -140,7 +140,7 @@ module.exports = class Node extends EventTarget {
     }
 
     child.$elm.remove();
-    this.dispatchEvent(new ChildListMutationEvent());
+    this._emitter.emit("ChildListMutationEvent", this);
     return child;
   }
   replaceChild(newChild, oldChild) {
@@ -156,7 +156,7 @@ module.exports = class Node extends EventTarget {
 
     oldChild.$elm.replaceWith(newChild.nodeType === nodeTypes.TEXT_NODE ? newChild.textContent : newChild.outerHTML);
 
-    this.dispatchEvent(new ChildListMutationEvent());
+    this._emitter.emit("ChildListMutationEvent", this);
     return oldChild;
   }
   _getElement($ref) {

--- a/lib/NodeList.js
+++ b/lib/NodeList.js
@@ -42,9 +42,8 @@ class ListHandler {
 }
 
 module.exports = class NodeList {
-  constructor(parentElement, selector, options = { attributes: true }, debug) {
+  constructor(parentElement, selector, options = { attributes: true }) {
     const liveList = this[kLiveList] = [];
-    this.debug = !!debug;
     this[kElement] = parentElement;
     this[kSelector] = selector;
     this[kOptions] = options;
@@ -68,7 +67,6 @@ module.exports = class NodeList {
   }
   _updateList() {
     const liveList = this[kLiveList];
-    if (this.debug) console.log("update list", liveList.length);
     const element = this[kElement];
     const selector = this[kSelector];
     const { filter } = this[kOptions];
@@ -79,7 +77,6 @@ module.exports = class NodeList {
     const list = $nodes.map((_, elm) => element.ownerDocument._getElement(elm)).toArray();
     liveList.length = 0;
     liveList.splice(0, -1, ...list);
-    if (this.debug) console.log("done", liveList.length);
   }
   [Symbol.iterator]() {
     return this[kLiveList][Symbol.iterator]();

--- a/lib/NodeList.js
+++ b/lib/NodeList.js
@@ -42,8 +42,9 @@ class ListHandler {
 }
 
 module.exports = class NodeList {
-  constructor(parentElement, selector, options = { attributes: true }) {
+  constructor(parentElement, selector, options = { attributes: true }, debug) {
     const liveList = this[kLiveList] = [];
+    this.debug = !!debug;
     this[kElement] = parentElement;
     this[kSelector] = selector;
     this[kOptions] = options;
@@ -67,6 +68,7 @@ module.exports = class NodeList {
   }
   _updateList() {
     const liveList = this[kLiveList];
+    if (this.debug) console.log("update list", liveList.length);
     const element = this[kElement];
     const selector = this[kSelector];
     const { filter } = this[kOptions];
@@ -77,6 +79,7 @@ module.exports = class NodeList {
     const list = $nodes.map((_, elm) => element.ownerDocument._getElement(elm)).toArray();
     liveList.length = 0;
     liveList.splice(0, -1, ...list);
+    if (this.debug) console.log("done", liveList.length);
   }
   [Symbol.iterator]() {
     return this[kLiveList][Symbol.iterator]();

--- a/lib/NodeList.js
+++ b/lib/NodeList.js
@@ -49,14 +49,11 @@ module.exports = class NodeList {
     this[kOptions] = options;
     if (!options?.disconnected) {
       const observer = new MutationObserver(this._updateList.bind(this));
-      observer.observe(parentElement, {
-        attributes: true,
-        childList: true,
-        subtree: true,
-        _internal: true,
-      });
+      console.log(parentElement.tagName, options);
+      observer.observe(parentElement, options);
     }
     this._updateList();
+    console.log("constructed", liveList.length);
 
     Object.defineProperty(this, "length", {
       enumerable: true,
@@ -73,17 +70,25 @@ module.exports = class NodeList {
   _updateList(records) {
     const liveList = this[kLiveList];
     const { attributes, filter } = this[kOptions];
+    console.log("update list", { liveList, attributes });
     if (records && attributes) {
       let inList = false;
       for (const record of records) {
+        console.log(record);
         if (record.type === "childList") {
+          console.log(1);
           inList = true;
           break;
         } else if (record.type === "attributes" && liveList.indexOf(record.target) > -1) {
+          console.log(2);
           inList = true;
           break;
+        } else {
+          console.log(3);
         }
       }
+
+      console.log("inList", inList);
       if (!inList) return;
     }
     const element = this[kElement];
@@ -93,8 +98,10 @@ module.exports = class NodeList {
       $nodes = $nodes.filter((idx, el) => filter(idx, element.ownerDocument.$(el)));
     }
     const list = $nodes.map((_, elm) => element.ownerDocument._getElement(elm)).toArray();
+    console.log("pre", liveList.length);
     liveList.length = 0;
     liveList.splice(0, -1, ...list);
+    console.log("post", liveList.length);
   }
   [Symbol.iterator]() {
     return this[kLiveList][Symbol.iterator]();

--- a/lib/NodeList.js
+++ b/lib/NodeList.js
@@ -49,11 +49,9 @@ module.exports = class NodeList {
     this[kOptions] = options;
     if (!options?.disconnected) {
       const observer = new MutationObserver(this._updateList.bind(this));
-      console.log(parentElement.tagName, options);
       observer.observe(parentElement, options);
     }
     this._updateList();
-    console.log("constructed", liveList.length);
 
     Object.defineProperty(this, "length", {
       enumerable: true,
@@ -67,41 +65,18 @@ module.exports = class NodeList {
   toString() {
     return `[object ${this.constructor.name}]`;
   }
-  _updateList(records) {
+  _updateList() {
     const liveList = this[kLiveList];
-    const { attributes, filter } = this[kOptions];
-    console.log("update list", { liveList, attributes });
-    if (records && attributes) {
-      let inList = false;
-      for (const record of records) {
-        console.log(record);
-        if (record.type === "childList") {
-          console.log(1);
-          inList = true;
-          break;
-        } else if (record.type === "attributes" && liveList.indexOf(record.target) > -1) {
-          console.log(2);
-          inList = true;
-          break;
-        } else {
-          console.log(3);
-        }
-      }
-
-      console.log("inList", inList);
-      if (!inList) return;
-    }
     const element = this[kElement];
     const selector = this[kSelector];
+    const { filter } = this[kOptions];
     let $nodes = selector !== undefined ? element.$elm.find(selector) : element.$elm.contents();
     if (filter) {
       $nodes = $nodes.filter((idx, el) => filter(idx, element.ownerDocument.$(el)));
     }
     const list = $nodes.map((_, elm) => element.ownerDocument._getElement(elm)).toArray();
-    console.log("pre", liveList.length);
     liveList.length = 0;
     liveList.splice(0, -1, ...list);
-    console.log("post", liveList.length);
   }
   [Symbol.iterator]() {
     return this[kLiveList][Symbol.iterator]();

--- a/lib/NodeList.js
+++ b/lib/NodeList.js
@@ -49,7 +49,12 @@ module.exports = class NodeList {
     this[kOptions] = options;
     if (!options?.disconnected) {
       const observer = new MutationObserver(this._updateList.bind(this));
-      observer.observe(parentElement, { childList: true, attributes: true });
+      observer.observe(parentElement, {
+        attributes: true,
+        childList: true,
+        subtree: true,
+        _internal: true,
+      });
     }
     this._updateList();
 

--- a/lib/RadioNodeList.js
+++ b/lib/RadioNodeList.js
@@ -5,7 +5,7 @@ const NodeList = require("./NodeList.js");
 module.exports = class RadioNodeList extends NodeList {
   constructor(parentElement, name) {
     const selector = `input[type=radio][name="${name}"]`;
-    super(parentElement, selector, { attributes: true });
+    super(parentElement, selector, { attributes: true, childList: true });
   }
   get value() {
     for (const option of Array.from(this)) {

--- a/lib/getElements.js
+++ b/lib/getElements.js
@@ -15,10 +15,10 @@ function getElementsByClassName(parentElement, classNames) {
     else result += noMatch;
     return result;
   }, "");
-  return new HTMLCollection(parentElement, selector, { attributes: true });
+  return new HTMLCollection(parentElement, selector, { attributes: true, childList: true, subtree: true });
 }
 
 function getElementsByTagName(parentElement, tagName) {
   const selector = tagName && tagName.trim().match(/^([_a-zA-Z]+[_a-zA-Z0-9-]*)$/)[1];
-  return new HTMLCollection(parentElement, selector, { attributes: false });
+  return new HTMLCollection(parentElement, selector, { childList: true, subtree: true });
 }

--- a/lib/getElements.js
+++ b/lib/getElements.js
@@ -20,5 +20,5 @@ function getElementsByClassName(parentElement, classNames) {
 
 function getElementsByTagName(parentElement, tagName) {
   const selector = tagName && tagName.trim().match(/^([_a-zA-Z]+[_a-zA-Z0-9-]*)$/)[1];
-  return new HTMLCollection(parentElement, selector, { childList: true, subtree: true });
+  return new HTMLCollection(parentElement, selector, { childList: true, subtree: true }, tagName === "b-a-d");
 }

--- a/test/HTMLCollection-test.js
+++ b/test/HTMLCollection-test.js
@@ -78,7 +78,7 @@ describe("HTMLCollection", () => {
   });
 
   it("result can be for looped", () => {
-    const elements = new HTMLCollection(document.body, "div", { attributes: false });
+    const elements = new HTMLCollection(document.body, "div");
     expect(elements.length).to.equal(3);
 
     const tags = [];
@@ -91,7 +91,7 @@ describe("HTMLCollection", () => {
   });
 
   it("result can be for-of looped", () => {
-    const elements = new HTMLCollection(document.body, "div", { attributes: false });
+    const elements = new HTMLCollection(document.body, "div");
     expect(elements.length).to.equal(3);
 
     const tags = [];
@@ -104,7 +104,7 @@ describe("HTMLCollection", () => {
   });
 
   it("result can be for-in looped", () => {
-    const elements = new HTMLCollection(document.body, "div", { attributes: false });
+    const elements = new HTMLCollection(document.body, "div");
     expect(elements.length).to.equal(3);
 
     const tags = [];
@@ -155,7 +155,7 @@ describe("HTMLCollection", () => {
     });
 
     it("mutates document tag collection", () => {
-      const elements = new HTMLCollection(document.documentElement, "div", { attributes: false });
+      const elements = new HTMLCollection(document.documentElement, "div");
       expect(elements.length).to.equal(3);
 
       const firstItem = elements[0];
@@ -175,7 +175,7 @@ describe("HTMLCollection", () => {
     });
 
     it("mutates parentNode tag collection", () => {
-      const elements = new HTMLCollection(document.body, "div", { attributes: false });
+      const elements = new HTMLCollection(document.body, "div");
       expect(elements.length).to.equal(3);
 
       const firstItem = elements[0];
@@ -185,7 +185,7 @@ describe("HTMLCollection", () => {
     });
 
     it("mutates parent parentNode tag collection", () => {
-      const elements = new HTMLCollection(document.body, "p", { attributes: false });
+      const elements = new HTMLCollection(document.body, "p");
       expect(elements.length).to.equal(1);
 
       const firstItem = elements[0];

--- a/test/HTMLSelectElement-test.js
+++ b/test/HTMLSelectElement-test.js
@@ -327,7 +327,6 @@ describe("HTMLSelectElement", () => {
     it("should return selected option in selectedOptions", () => {
       const [ select ] = document.getElementsByTagName("select");
       select.options[1].selected = true;
-      console.log("set 2");
       select.options[2].selected = true;
       expect(select.selectedIndex).to.equal(2);
       expect(select.selectedOptions).to.have.length(1);

--- a/test/HTMLSelectElement-test.js
+++ b/test/HTMLSelectElement-test.js
@@ -327,6 +327,7 @@ describe("HTMLSelectElement", () => {
     it("should return selected option in selectedOptions", () => {
       const [ select ] = document.getElementsByTagName("select");
       select.options[1].selected = true;
+      console.log("set 2");
       select.options[2].selected = true;
       expect(select.selectedIndex).to.equal(2);
       expect(select.selectedOptions).to.have.length(1);

--- a/test/elements-test.js
+++ b/test/elements-test.js
@@ -2,6 +2,7 @@
 
 const DocumentFragment = require("../lib/DocumentFragment.js");
 const Element = require("../lib/Element.js");
+const Window = require("../lib/Window.js");
 const HTMLAnchorElement = require("../lib/HTMLAnchorElement.js");
 const HTMLFormElement = require("../lib/HTMLFormElement.js");
 const { Document } = require("../lib/index.js");
@@ -406,11 +407,7 @@ describe("elements", () => {
     describe("appendChild(aChild)", () => {
       let document;
       beforeEach(() => {
-        const window = {
-          get window() {
-            return this;
-          },
-        };
+        const window = new Window({});
         document = new Document({
           text: `
             <html>

--- a/test/mutation-observer-test.js
+++ b/test/mutation-observer-test.js
@@ -170,8 +170,8 @@ describe("MutationObserver", () => {
     let browser, observer;
     beforeEach(async () => {
       browser = await new Browser().load(`
-          <html>
-            <body>
+        <html>
+          <body>
             <h1>Welcome to Tallahassee!</h1>
           </body>
         </html>
@@ -454,6 +454,48 @@ describe("MutationObserver", () => {
             expect(mutationRecord.target).to.equal(outside ? element.parentElement : element);
           }
         });
+      });
+
+      it("is triggered by Element.remove()", () => {
+        const node = browser.document.body;
+        observer.observe(node, allOptions);
+
+        node.firstElementChild.remove();
+
+        expect(mutations.count).to.deep.equal({
+          attributes: 0,
+          childList: 1,
+        });
+
+        for (const mutationRecord of mutations.records) {
+          expect(mutationRecord.target).to.equal(node);
+        }
+      });
+
+      it("is triggered by Element.replaceChildren()", () => {
+        const node = browser.document.body;
+        observer.observe(node, allOptions);
+
+        node.replaceChildren();
+
+        expect(mutations.count).to.deep.equal({
+          attributes: 0,
+          childList: 1,
+        });
+
+        node.replaceChildren(
+          browser.document.createElement("p"),
+          browser.document.createElement("p")
+        );
+
+        expect(mutations.count).to.deep.equal({
+          attributes: 0,
+          childList: 2,
+        });
+
+        for (const mutationRecord of mutations.records) {
+          expect(mutationRecord.target).to.equal(node);
+        }
       });
 
       it("is triggered by HTMLElement.innerText = text", () => {

--- a/test/mutation-observer-test.js
+++ b/test/mutation-observer-test.js
@@ -155,7 +155,7 @@ describe("MutationObserver", () => {
     const browser = await new Browser(app).navigateTo("/");
 
     const targetNode = browser.document.getElementsByTagName("body")[0];
-    const config = { attributes: true, childList: true };
+    const config = { childList: true, subtree: true };
     let childListMutation = false;
     const callback = function (mutationsList) {
       for (const mutation of mutationsList) {
@@ -184,7 +184,7 @@ describe("MutationObserver", () => {
     p.textContent = "some text";
     browser.document.getElementById("header-1").appendChild(p);
 
-    const config = { attributes: true, childList: true };
+    const config = { childList: true, subtree: true };
     let childListMutation = false;
     const callback = function (mutationsList) {
       for (const mutation of mutationsList) {
@@ -351,12 +351,12 @@ describe("MutationObserver", () => {
     const browser = await new Browser(app).navigateTo("/");
 
     const targetNode = browser.document.getElementsByTagName("body")[0];
-    const config = { attributes: true, childList: true };
-    let childListMutation = false;
+    const config = { characterData: true };
+    let characterDataMutation = false;
     const callback = function (mutationsList) {
       for (const mutation of mutationsList) {
-        if (mutation.type === "childList") {
-          childListMutation = true;
+        if (mutation.type === "characterData") {
+          characterDataMutation = true;
         }
       }
     };
@@ -364,19 +364,19 @@ describe("MutationObserver", () => {
     observer.observe(targetNode, config);
 
     targetNode.textContent = "Foo";
-    expect(childListMutation).to.be.ok;
+    expect(characterDataMutation).to.be.ok;
   });
 
   it("triggers when element has been inserted into the observed node using innerText", async () => {
     const browser = await new Browser(app).navigateTo("/");
 
     const targetNode = browser.document.getElementsByTagName("body")[0];
-    const config = { attributes: true, childList: true };
-    let childListMutation = false;
+    const config = { characterData: true };
+    let characterDataMutation = false;
     const callback = function (mutationsList) {
       for (const mutation of mutationsList) {
-        if (mutation.type === "childList") {
-          childListMutation = true;
+        if (mutation.type === "characterData") {
+          characterDataMutation = true;
         }
       }
     };
@@ -384,7 +384,7 @@ describe("MutationObserver", () => {
     observer.observe(targetNode, config);
 
     targetNode.innerText = "Foo";
-    expect(childListMutation).to.be.ok;
+    expect(characterDataMutation).to.be.ok;
   });
 
   it("triggers when element has been removed from the observed node using removeChild", async () => {

--- a/test/mutation-observer-test.js
+++ b/test/mutation-observer-test.js
@@ -40,22 +40,17 @@ describe("MutationObserver", () => {
       return { ads };
 
       function scan() {
-        console.log("scan", ads.length, "/", slots.length);
         for (const slot of slots) {
           if (ads.includes(slot)) continue;
           ads.push(slot);
         }
-        console.log("done", ads.length, "/", slots.length);
       }
     }
 
     function continuousScroll() {
       browser.window.addEventListener("scroll", async () => {
-        console.log("scrolled");
         const html = await loadArticle();
-        console.log("loaded");
         browser.document.body.insertAdjacentHTML("beforeend", html);
-        console.log("added", browser.document.body.lastElementChild.id);
       });
 
       function loadArticle() {
@@ -153,8 +148,8 @@ describe("MutationObserver", () => {
       });
 
       function recordMutations(mutationsList) {
-        for (const { type } of mutationsList) {
-          mutations[type]++;
+        for (const mutation of mutationsList) {
+          mutations[mutation.type]++;
         }
       }
     });
@@ -595,24 +590,6 @@ describe("MutationObserver", () => {
       expect(record).to.have.property("type", "attributes");
       expect(record).to.have.property("attributeName", "id");
       expect(record.target === browser.document.body).to.be.true;
-    });
-
-    it("observer with attributes and subtree option calls callback when element child src changes", () => {
-      const records = [];
-      const observer = new browser.window.MutationObserver((mutatedRecords) => {
-        records.push(...mutatedRecords);
-      });
-      observer.observe(browser.document.body, { attributes: true, subtree: true });
-
-      const img = browser.document.getElementsByTagName("img")[0];
-      img.src = "/images/tallahassee-2.png";
-
-      expect(records).to.have.length(1);
-
-      const record = records[0];
-      expect(record).to.have.property("type", "attributes");
-      expect(record).to.have.property("attributeName", "src");
-      expect(record.target === img).to.be.true;
     });
 
     it("observer with attributes and subtree option calls callback when element child src changes", () => {

--- a/test/mutation-observer-test.js
+++ b/test/mutation-observer-test.js
@@ -1,683 +1,502 @@
 "use strict";
 
-const Script = require("@bonniernews/wichita");
-const path = require("path");
-
-const { app } = require("../app/app.js");
 const Browser = require("../index.js");
 
 describe("MutationObserver", () => {
-  it("races", async () => {
-    let a = 0;
-    const buildArticle = () => `
-      <article id="article-${a++}">
-        <b-a-d />
-        <b-a-d />
-        <b-a-d />
-      </article>
-    `;
+  const mutations = {
+    count: {
+      attributes: 0,
+      childList: 0,
+    },
+    records: [],
+  };
 
-    const browser = await new Browser().load(buildArticle());
-    const BAD = fakeBAD();
-    continuousScroll();
-    expect(BAD.ads.length).to.equal(3);
-
-    for (let i = 1; i < 3; i++) {
-      const mutation = mutated(browser.document.body);
-      browser.window.scroll(0, i);
-      await mutation;
-
-      expect(BAD.ads.length).to.equal((1 + i) * 3);
+  function recordMutations(mutationRecords) {
+    for (const { type } of mutationRecords) {
+      mutations.count[type]++;
     }
+    mutations.records.push(...mutationRecords);
+  }
 
-    function fakeBAD() {
-      const ads = [];
-      const slots = browser.document.body.getElementsByTagName("b-a-d");
-      const observer = new browser.window.MutationObserver(scan);
-      observer.observe(browser.document.body, { childList: true, subtree: true });
-      scan();
-
-      return { ads };
-
-      function scan() {
-        for (const slot of slots) {
-          if (ads.includes(slot)) continue;
-          ads.push(slot);
-        }
-      }
+  function resetMutations() {
+    for (const type of Object.keys(mutations.count)) {
+      mutations.count[type] = 0;
     }
+    mutations.records.length = 0;
+  }
 
-    function continuousScroll() {
-      browser.window.addEventListener("scroll", async () => {
-        const html = await loadArticle();
-        browser.document.body.insertAdjacentHTML("beforeend", html);
+  describe("new MutationObserver(callback)", () => {
+    describe("mutationObserver.observe(target, options)", () => {
+      [
+        { attributes: true },
+        { childList: true },
+        { attributes: true, childList: true },
+        { attributes: true, subtree: true },
+        { childList: true, subtree: true },
+        { attributes: true, childList: true, subtree: true },
+      ].forEach((options) => {
+        describe(`options: ${JSON.stringify(options)}`, () => {
+          before(resetMutations);
+
+          let browser, observer, element;
+          before(async () => {
+            browser = await new Browser().load("<html/>");
+            element = browser.document.body;
+            observer = new browser.window.MutationObserver(recordMutations);
+            observer.observe(element, options);
+          });
+
+          it("no mutations", () => {
+            expect(mutations.count).to.deep.equal({
+              attributes: 0,
+              childList: 0,
+            });
+          });
+
+          it("attribute mutation", () => {
+            element.setAttribute("lang", "en");
+            expect(mutations.count).to.deep.equal({
+              attributes: options.attributes ? 1 : 0,
+              childList: 0,
+            });
+          });
+
+          let childElement;
+          it("child list mutation", () => {
+            childElement = browser.document.createElement("a");
+            element.appendChild(childElement);
+            expect(mutations.count).to.deep.equal({
+              attributes: options.attributes ? 1 : 0,
+              childList: options.childList ? 1 : 0,
+            });
+          });
+
+          it("attribute mutation in subtree", () => {
+            childElement.setAttribute("href", "https://github.com/BonnierNews/tallahassee");
+            expect(mutations.count).to.deep.equal(
+              options.subtree ?
+                {
+                  attributes: options.attributes ? 2 : 0,
+                  childList: options.childList ? 1 : 0,
+                } :
+                {
+                  attributes: options.attributes ? 1 : 0,
+                  childList: options.childList ? 1 : 0,
+                }
+            );
+          });
+
+          it("child list mutation in subtree", () => {
+            childElement.textContent = "Welcome to Tallahassee!";
+            expect(mutations.count).to.deep.equal(
+              options.subtree ?
+                {
+                  attributes: options.attributes ? 2 : 0,
+                  childList: options.childList ? 2 : 0,
+                } :
+                {
+                  attributes: options.attributes ? 1 : 0,
+                  childList: options.childList ? 1 : 0,
+                }
+            );
+          });
+        });
       });
 
-      function loadArticle() {
-        return new Promise((r) => setTimeout(r, 100, buildArticle()));
-      }
-    }
+      it("mutationObserver.observe(targetN, optionsN)", async () => {
+        resetMutations();
+        const browser = await new Browser().load("<html/>");
+        const observer = new browser.window.MutationObserver(recordMutations);
 
-    function mutated(target) {
-      return new Promise((resolve) => {
-        const observer = new browser.window.MutationObserver(update);
+        const target = browser.document.createElement("p");
+        observer.observe(target, { attributes: true });
         observer.observe(target, { childList: true });
 
-        function update() {
-          observer.disconnect();
-          resolve();
-        }
-      });
-    }
-  });
+        target.setAttribute("lang", "fl");
+        target.textContent = "Welcome to Tallahassee!";
 
-  [
-    { attributes: true },
-    { childList: true },
-    { attributes: true, childList: true },
-    { attributes: true, subtree: true },
-    { childList: true, subtree: true },
-    { attributes: true, childList: true, subtree: true },
-  ].forEach((options) => {
-    describe(`options: ${JSON.stringify(options)}`, () => {
-      const mutations = {
-        attributes: 0,
-        childList: 0,
-      };
-      let browser, element;
-      before(async () => {
-        browser = await new Browser().load("<html/>");
+        expect(mutations.records.length).to.equal(2);
+        expect(mutations.records[0]).to.deep.include({
+          target,
+          type: "attributes",
+        });
+        expect(mutations.records[1]).to.deep.include({
+          target,
+          type: "childList",
+        });
+      });
+
+      it("mutationObserver.observe(target, optionsN)", async () => {
+        resetMutations();
+        const browser = await new Browser().load("<html/>");
         const observer = new browser.window.MutationObserver(recordMutations);
-        element = browser.document.body;
-        observer.observe(element, options);
-      });
 
-      it("no mutations", () => {
-        expect(mutations).to.deep.equal({
-          attributes: 0,
-          childList: 0,
+        const target1 = browser.document.createElement("p");
+        observer.observe(target1, { attributes: true });
+
+        const target2 = browser.document.createElement("p");
+        observer.observe(target2, { childList: true });
+
+        for (const target of [ target1, target2 ]) {
+          target.setAttribute("lang", "fl");
+          target.textContent = "Welcome to Tallahassee!";
+        }
+
+        expect(mutations.records.length).to.equal(2);
+        expect(mutations.records[0]).to.deep.include({
+          target: target1,
+          type: "attributes",
+        });
+        expect(mutations.records[1]).to.deep.include({
+          target: target2,
+          type: "childList",
         });
       });
+    });
 
-      it("attribute mutation", () => {
-        element.setAttribute("lang", "en");
-        expect(mutations).to.deep.equal({
-          attributes: options.attributes ? 1 : 0,
-          childList: 0,
+    describe("mutationObserver.disconnect()", () => {
+      before(resetMutations);
+
+      it("stops listening for all mutations", async () => {
+        const browser = await new Browser().load("<html/>");
+        const element = browser.document.body;
+        const observer = new browser.window.MutationObserver(function () {
+          expect(this).to.equal(observer);
+          recordMutations.apply(this, arguments);
         });
-      });
+        observer.observe(element, { attributes: true, childList: true, subtree: true });
 
-      let childElement;
-      it("child list mutation", () => {
-        childElement = browser.document.createElement("a");
+        const childElement = browser.document.createElement("p");
         element.appendChild(childElement);
-        expect(mutations).to.deep.equal({
-          attributes: options.attributes ? 1 : 0,
-          childList: options.childList ? 1 : 0,
+        childElement.setAttribute("lang", "fl");
+        childElement.textContent = "Welcome to Tallahassee!";
+
+        expect(mutations.count).to.deep.equal({
+          attributes: 1,
+          childList: 2,
+        });
+
+        observer.disconnect();
+
+        childElement.setAttribute("lang", "en");
+        childElement.textContent = "Goodbye!";
+
+        expect(mutations.count).to.deep.equal({
+          attributes: 1,
+          childList: 2,
+        });
+      });
+    });
+  });
+
+  describe("Mutations", () => {
+    beforeEach(resetMutations);
+
+    const allOptions = { attributes: true, childList: true, subtree: true };
+    let browser, observer;
+    beforeEach(async () => {
+      browser = await new Browser().load(`
+          <html>
+            <body>
+            <h1>Welcome to Tallahassee!</h1>
+          </body>
+        </html>
+      `);
+
+      observer = new browser.window.MutationObserver(recordMutations);
+    });
+
+    describe("type: attributes", () => {
+      it("is triggered by Element.attributes.*.value = value", () => {
+        const element = browser.document.body;
+        browser.document.body.setAttribute("lang", "en");
+        observer.observe(element, allOptions);
+
+        browser.document.body.attributes.lang.value = "fl";
+
+        expect(mutations.count).to.deep.equal({
+          attributes: 1,
+          childList: 0,
+        });
+
+        for (const mutationRecord of mutations.records) {
+          expect(mutationRecord.target).to.equal(element);
+          expect(mutationRecord.attributeName).to.equal("lang");
+        }
+      });
+
+      it("is triggered by Element.classList.*(className)", () => {
+        const element = browser.document.body;
+        observer.observe(element, allOptions);
+
+        element.classList.add("color-scheme-dark");
+        element.classList.toggle("color-scheme-dark");
+        element.classList.toggle("color-scheme-dark");
+        element.classList.remove("color-scheme-dark");
+
+        expect(mutations.count).to.deep.equal({
+          attributes: 4,
+          childList: 0,
+        });
+
+        for (const mutationRecord of mutations.records) {
+          expect(mutationRecord.target).to.equal(element);
+          expect(mutationRecord.attributeName).to.equal("class");
+        }
+      });
+
+      it("is triggered by Element.setAttribute(name, value)", () => {
+        const element = browser.document.body;
+        observer.observe(element, allOptions);
+
+        element.setAttribute("lang", "en");
+
+        expect(mutations.count).to.deep.equal({
+          attributes: 1,
+          childList: 0,
+        });
+
+        for (const mutationRecord of mutations.records) {
+          expect(mutationRecord.target).to.equal(element);
+          expect(mutationRecord.attributeName).to.equal("lang");
+        }
+      });
+
+      it("is triggered by Element.removeAttribute(name)", () => {
+        const element = browser.document.body;
+        element.setAttribute("lang", "en");
+
+        observer.observe(element, allOptions);
+
+        element.removeAttribute("lang");
+        element.removeAttribute("lang");
+
+        expect(mutations.count).to.deep.equal({
+          attributes: 1,
+          childList: 0,
+        });
+
+        for (const mutationRecord of mutations.records) {
+          expect(mutationRecord.target).to.equal(element);
+          expect(mutationRecord.attributeName).to.equal("lang");
+        }
+      });
+
+      it("is triggered by HTMLElement.dataset.* = data", () => {
+        const htmlElement = browser.document.body;
+        observer.observe(htmlElement, allOptions);
+
+        htmlElement.dataset.tallahassee = "fl";
+
+        expect(mutations.count).to.deep.equal({
+          attributes: 1,
+          childList: 0,
+        });
+
+        for (const mutationRecord of mutations.records) {
+          expect(mutationRecord.target).to.equal(htmlElement);
+          expect(mutationRecord.attributeName).to.equal("data-tallahassee");
+        }
+      });
+
+      it("is triggered by HTMLImageElement.src = src", () => {
+        const htmlImageElement = browser.document.createElement("img");
+        observer.observe(htmlImageElement, allOptions);
+
+        htmlImageElement.src = "/images/tallahassee.png";
+
+        expect(mutations.count).to.deep.equal({
+          attributes: 1,
+          childList: 0,
+        });
+
+        for (const mutationRecord of mutations.records) {
+          expect(mutationRecord.target).to.equal(htmlImageElement);
+          expect(mutationRecord.attributeName).to.equal("src");
+        }
+      });
+    });
+
+    describe("type: childList", () => {
+      it("is triggered by Node.textContent = text", () => {
+        const node = browser.document.querySelector("h1");
+        observer.observe(node, allOptions);
+
+        node.textContent = "Good bye!";
+
+        expect(mutations.count).to.deep.equal({
+          attributes: 0,
+          childList: 1,
+        });
+
+        for (const mutationRecord of mutations.records) {
+          expect(mutationRecord.target).to.equal(node);
+        }
+      });
+
+      it("is triggered by Node.appendChild(child)", () => {
+        const node = browser.document.body;
+        observer.observe(node, allOptions);
+
+        node.appendChild(browser.document.createElement("p"));
+
+        expect(mutations.count).to.deep.equal({
+          attributes: 0,
+          childList: 1,
+        });
+
+        for (const mutationRecord of mutations.records) {
+          expect(mutationRecord.target).to.equal(node);
+        }
+      });
+
+      it("is triggered by Node.appendChild(htmlScriptElement)", () => {
+        const sequence = browser.window.sequence = [];
+        const node = browser.document.body;
+        observer = new browser.window.MutationObserver(() => {
+          sequence.push("mutation observer callback");
+        });
+        observer.observe(node, allOptions);
+
+        const htmlScriptElement = browser.document.createElement("script");
+        htmlScriptElement.textContent = "window.sequence.push('script execution');";
+        node.appendChild(htmlScriptElement);
+
+        expect(sequence).to.deep.equal([
+          "script execution",
+          "mutation observer callback",
+        ]);
+      });
+
+      it("is triggered by Node.insertBefore(newNode, referenceNode)", () => {
+        const node = browser.document.body;
+        observer.observe(node, allOptions);
+
+        node.insertBefore(
+          browser.document.createElement("p"),
+          node.firstChild
+        );
+
+        expect(mutations.count).to.deep.equal({
+          attributes: 0,
+          childList: 1,
+        });
+
+        for (const mutationRecord of mutations.records) {
+          expect(mutationRecord.target).to.equal(node);
+        }
+      });
+
+      it("is triggered by Node.removeChild(child)", () => {
+        const node = browser.document.body;
+        observer.observe(node, allOptions);
+
+        node.removeChild(node.firstChild);
+
+        expect(mutations.count).to.deep.equal({
+          attributes: 0,
+          childList: 1,
+        });
+
+        for (const mutationRecord of mutations.records) {
+          expect(mutationRecord.target).to.equal(node);
+        }
+      });
+
+      it("is triggered by Element.innerHTML = html", () => {
+        const element = browser.document.body;
+        observer.observe(element, allOptions);
+
+        element.innerHTML = "<p />";
+
+        expect(mutations.count).to.deep.equal({
+          attributes: 0,
+          childList: 1,
+        });
+
+        for (const mutationRecord of mutations.records) {
+          expect(mutationRecord.target).to.equal(element);
+        }
+      });
+
+      it("is triggered by Element.outerHTML = html", () => {
+        const element = browser.document.body;
+        const { parentElement } = element;
+        observer.observe(parentElement, allOptions);
+
+        element.outerHTML = "<p />";
+
+        expect(mutations.count).to.deep.equal({
+          attributes: 0,
+          childList: 1,
+        });
+
+        for (const mutationRecord of mutations.records) {
+          expect(mutationRecord.target).to.equal(parentElement);
+        }
+      });
+
+      [
+        [ "beforebegin", true ],
+        [ "afterbegin", false ],
+        [ "beforeend", false ],
+        [ "afterend", true ],
+      ].forEach(([ position, outside ]) => {
+        it(`is triggered by Element.insertAdjacentElement("${position}", element)`, () => {
+          const element = browser.document.body;
+          observer.observe(outside ? element.parentElement : element, allOptions);
+
+          element.insertAdjacentElement(position, browser.document.createElement("p"));
+
+          expect(mutations.count).to.deep.equal({
+            attributes: 0,
+            childList: 1,
+          });
+
+          for (const mutationRecord of mutations.records) {
+            expect(mutationRecord.target).to.equal(outside ? element.parentElement : element);
+          }
         });
       });
 
-      it("attribute mutation in subtree", () => {
-        childElement.setAttribute("href", "https://github.com/BonnierNews/tallahassee");
-        expect(mutations).to.deep.equal(
-          options.subtree ?
-            {
-              attributes: options.attributes ? 2 : 0,
-              childList: options.childList ? 1 : 0,
-            } :
-            {
-              attributes: options.attributes ? 1 : 0,
-              childList: options.childList ? 1 : 0,
-            }
-        );
+      [
+        [ "beforebegin", true ],
+        [ "afterbegin", false ],
+        [ "beforeend", false ],
+        [ "afterend", true ],
+      ].forEach(([ position, outside ]) => {
+        it(`is triggered by Element.insertAdjacentHTML("${position}", text)`, () => {
+          const element = browser.document.body;
+          observer.observe(outside ? element.parentElement : element, allOptions);
+
+          element.insertAdjacentHTML(position, "<p />");
+
+          expect(mutations.count).to.deep.equal({
+            attributes: 0,
+            childList: 1,
+          });
+
+          for (const mutationRecord of mutations.records) {
+            expect(mutationRecord.target).to.equal(outside ? element.parentElement : element);
+          }
+        });
       });
 
-      it("child list mutation in subtree", () => {
-        childElement.textContent = "Welcome to Tallahassee!";
-        expect(mutations).to.deep.equal(
-          options.subtree ?
-            {
-              attributes: options.attributes ? 2 : 0,
-              childList: options.childList ? 2 : 0,
-            } :
-            {
-              attributes: options.attributes ? 1 : 0,
-              childList: options.childList ? 1 : 0,
-            }
-        );
+      it("is triggered by HTMLElement.innerText = text", () => {
+        const htmlElement = browser.document.querySelector("h1");
+        observer.observe(htmlElement, allOptions);
+
+        htmlElement.innerText = "Good bye!";
+
+        expect(mutations.count).to.deep.equal({
+          attributes: 0,
+          childList: 1,
+        });
+
+        for (const mutationRecord of mutations.records) {
+          expect(mutationRecord.target).to.equal(htmlElement);
+        }
       });
-
-      function recordMutations(mutationsList) {
-        for (const mutation of mutationsList) {
-          mutations[mutation.type]++;
-        }
-      }
-    });
-  });
-
-  it("triggers when element has been inserted into the observed node using appendChild", async () => {
-    const browser = await new Browser(app).navigateTo("/", { cookie: "_ga=1" });
-
-    const targetNode = browser.document.getElementsByTagName("body")[0];
-    const config = { attributes: true, childList: true };
-    let childListMutation = false;
-    function callback(mutationsList) {
-      for (const mutation of mutationsList) {
-        if (mutation.type === "childList") {
-          childListMutation = true;
-        }
-      }
-    }
-    const observer = new browser.window.MutationObserver(callback);
-    observer.observe(targetNode, config);
-
-    await new Script(path.resolve("app/assets/scripts/main.js")).run(browser.window);
-
-    expect(childListMutation).to.be.ok;
-  });
-
-  it("triggers when element has been inserted into a child of the observed node using appendChild", async () => {
-    const browser = await new Browser(app).navigateTo("/");
-
-    const targetNode = browser.document.getElementsByTagName("body")[0];
-    const config = { childList: true, subtree: true };
-    let childListMutation = false;
-    const callback = function (mutationsList) {
-      for (const mutation of mutationsList) {
-        if (mutation.type === "childList") {
-          childListMutation = true;
-        }
-      }
-    };
-    const observer = new browser.window.MutationObserver(callback);
-    observer.observe(targetNode, config);
-
-    const p = browser.document.createElement("p");
-    p.classList.add("set-by-js");
-    p.textContent = "some text";
-    browser.document.getElementById("header-1").appendChild(p);
-    expect(childListMutation).to.be.ok;
-  });
-
-  it("triggers when element has been inserted into a grand child of the observed node using appendChild", async () => {
-    const browser = await new Browser(app).navigateTo("/");
-
-    const targetNode = browser.document.getElementsByTagName("body")[0];
-    const p = browser.document.createElement("p");
-    p.classList.add("set-by-js");
-    p.id = "my-elm";
-    p.textContent = "some text";
-    browser.document.getElementById("header-1").appendChild(p);
-
-    const config = { childList: true, subtree: true };
-    let childListMutation = false;
-    const callback = function (mutationsList) {
-      for (const mutation of mutationsList) {
-        if (mutation.type === "childList") {
-          childListMutation = true;
-        }
-      }
-    };
-    const observer = new browser.window.MutationObserver(callback);
-    observer.observe(targetNode, config);
-
-    const span = browser.document.createElement("span");
-    span.classList.add("set-by-js");
-    span.textContent = "some other text";
-    browser.document.getElementById("my-elm").appendChild(span);
-    expect(childListMutation).to.be.ok;
-  });
-
-  it("triggers when element has been inserted into the observed node using insertAdjacentHTML(beforeend)", async () => {
-    const browser = await new Browser(app).navigateTo("/");
-
-    const targetNode = browser.document.getElementsByTagName("body")[0];
-    const config = { attributes: true, childList: true };
-    let childListMutation = false;
-    const callback = function (mutationsList) {
-      for (const mutation of mutationsList) {
-        if (mutation.type === "childList") {
-          childListMutation = true;
-        }
-      }
-    };
-    const observer = new browser.window.MutationObserver(callback);
-    observer.observe(targetNode, config);
-
-    targetNode.insertAdjacentHTML("beforeend", "<p>My paragraph</p>");
-    expect(childListMutation).to.be.ok;
-  });
-
-  it("triggers when element has been inserted into the observed node using insertAdjacentHTML(afterbegin)", async () => {
-    const browser = await new Browser(app).navigateTo("/");
-
-    const targetNode = browser.document.getElementsByTagName("body")[0];
-    const config = { attributes: true, childList: true };
-    let childListMutation = false;
-    const callback = function (mutationsList) {
-      for (const mutation of mutationsList) {
-        if (mutation.type === "childList") {
-          childListMutation = true;
-        }
-      }
-    };
-    const observer = new browser.window.MutationObserver(callback);
-    observer.observe(targetNode, config);
-
-    targetNode.insertAdjacentHTML("afterbegin", "<p>My paragraph</p>");
-    expect(childListMutation).to.be.ok;
-  });
-
-  it("doesn't trigger when element has been inserted into the observed node using insertAdjacentHTML(beforebegin)", async () => {
-    const browser = await new Browser(app).navigateTo("/");
-
-    const targetNode = browser.document.getElementsByTagName("body")[0];
-    const config = { attributes: true, childList: true };
-    let childListMutation = false;
-    const callback = function (mutationsList) {
-      for (const mutation of mutationsList) {
-        if (mutation.type === "childList") {
-          childListMutation = true;
-        }
-      }
-    };
-    const observer = new browser.window.MutationObserver(callback);
-    observer.observe(targetNode, config);
-
-    targetNode.insertAdjacentHTML("beforebegin", "<p>My paragraph</p>");
-    expect(childListMutation).to.not.be.ok;
-  });
-
-  it("doesn't trigger when element has been inserted into the observed node using insertAdjacentHTML(afterend)", async () => {
-    const browser = await new Browser(app).navigateTo("/");
-
-    const targetNode = browser.document.getElementsByTagName("body")[0];
-    const config = { attributes: true, childList: true };
-    let childListMutation = false;
-    const callback = function (mutationsList) {
-      for (const mutation of mutationsList) {
-        if (mutation.type === "childList") {
-          childListMutation = true;
-        }
-      }
-    };
-    const observer = new browser.window.MutationObserver(callback);
-    observer.observe(targetNode, config);
-
-    targetNode.insertAdjacentHTML("afterend", "<p>My paragraph</p>");
-    expect(childListMutation).to.not.be.ok;
-  });
-
-  it("triggers when element has been inserted into the observed node using insertBefore", async () => {
-    const browser = await new Browser(app).navigateTo("/");
-
-    const targetNode = browser.document.getElementsByTagName("body")[0];
-    const config = { attributes: true, childList: true };
-    let childListMutation = false;
-    const callback = function (mutationsList) {
-      for (const mutation of mutationsList) {
-        if (mutation.type === "childList") {
-          childListMutation = true;
-        }
-      }
-    };
-    const observer = new browser.window.MutationObserver(callback);
-    observer.observe(targetNode, config);
-
-    const p = browser.document.createElement("p");
-    p.classList.add("set-by-js");
-    p.textContent = "some text";
-    const header = browser.document.getElementById("header-1");
-    targetNode.insertBefore(p, header);
-    expect(childListMutation).to.be.ok;
-  });
-
-  it("triggers when element has been inserted into the observed node using innerHTML", async () => {
-    const browser = await new Browser(app).navigateTo("/");
-
-    const targetNode = browser.document.getElementsByTagName("body")[0];
-    const config = { attributes: true, childList: true };
-    let childListMutation = false;
-    const callback = function (mutationsList) {
-      for (const mutation of mutationsList) {
-        if (mutation.type === "childList") {
-          childListMutation = true;
-        }
-      }
-    };
-    const observer = new browser.window.MutationObserver(callback);
-    observer.observe(targetNode, config);
-
-    targetNode.innerHTML = "<p>Foo</p>";
-    expect(childListMutation).to.be.ok;
-  });
-
-  it("triggers when element has been inserted into the observed node using outerHTML", async () => {
-    const browser = await new Browser(app).navigateTo("/");
-
-    const targetNode = browser.document.getElementsByTagName("body")[0];
-    const config = { attributes: true, childList: true };
-    let childListMutation = false;
-    const callback = function (mutationsList) {
-      for (const mutation of mutationsList) {
-        if (mutation.type === "childList") {
-          childListMutation = true;
-        }
-      }
-    };
-    const observer = new browser.window.MutationObserver(callback);
-    observer.observe(targetNode, config);
-
-    targetNode.outerHTML = "<body><p>Foo</p></body>";
-    expect(childListMutation).to.be.ok;
-  });
-
-  it("triggers when element has been inserted into the observed node using textContent", async () => {
-    const browser = await new Browser(app).navigateTo("/");
-
-    const targetNode = browser.document.getElementsByTagName("body")[0];
-    const config = { childList: true };
-    let childListMutation = false;
-    const callback = function (mutationsList) {
-      for (const mutation of mutationsList) {
-        if (mutation.type === "childList") {
-          childListMutation = true;
-        }
-      }
-    };
-    const observer = new browser.window.MutationObserver(callback);
-    observer.observe(targetNode, config);
-
-    targetNode.textContent = "Foo";
-    expect(childListMutation).to.be.ok;
-  });
-
-  it("triggers when element has been inserted into the observed node using innerText", async () => {
-    const browser = await new Browser(app).navigateTo("/");
-
-    const targetNode = browser.document.getElementsByTagName("body")[0];
-    const config = { childList: true };
-    let childListMutation = false;
-    const callback = function (mutationsList) {
-      for (const mutation of mutationsList) {
-        if (mutation.type === "childList") {
-          childListMutation = true;
-        }
-      }
-    };
-    const observer = new browser.window.MutationObserver(callback);
-    observer.observe(targetNode, config);
-
-    targetNode.innerText = "Foo";
-    expect(childListMutation).to.be.ok;
-  });
-
-  it("triggers when element has been removed from the observed node using removeChild", async () => {
-    const browser = await new Browser(app).navigateTo("/");
-
-    const targetNode = browser.document.getElementsByTagName("body")[0];
-    const elementToRemove = browser.document.createElement("div");
-    targetNode.appendChild(elementToRemove);
-
-    const config = { attributes: true, childList: true };
-    let childListMutation = false;
-    const callback = function (mutationsList) {
-      for (const mutation of mutationsList) {
-        if (mutation.type === "childList") {
-          childListMutation = true;
-        }
-      }
-    };
-    const observer = new browser.window.MutationObserver(callback);
-    observer.observe(targetNode, config);
-
-    targetNode.removeChild(elementToRemove);
-    expect(childListMutation).to.be.ok;
-  });
-
-  it("disconnect() stops listening for mutations", async () => {
-    const browser = await new Browser(app).navigateTo("/");
-
-    const targetNode = browser.document.getElementsByTagName("body")[0];
-    const config = { attributes: true, childList: true };
-
-    let childMutationCount = 0;
-
-    const observer = new browser.window.MutationObserver(() => {
-      ++childMutationCount;
-    });
-    observer.observe(targetNode, config);
-
-    const p1 = browser.document.createElement("p");
-    targetNode.appendChild(p1);
-
-    observer.disconnect();
-
-    const p2 = browser.document.createElement("p");
-    targetNode.appendChild(p2);
-
-    expect(childMutationCount).to.equal(1);
-  });
-
-  it("mutation callback (non-arrow) is called with mutation scope", async () => {
-    const browser = await new Browser(app).navigateTo("/");
-
-    const targetNode = browser.document.getElementsByTagName("body")[0];
-    const config = { attributes: true, childList: true };
-
-    let scope;
-
-    const observer = new browser.window.MutationObserver(function mutationCallback() {
-      scope = this;
-    });
-    observer.observe(targetNode, config);
-
-    const p1 = browser.document.createElement("p");
-    targetNode.appendChild(p1);
-
-    expect(scope === observer).to.be.true;
-  });
-
-  it("mutation callback this.disconnect() stops listening for mutations", async () => {
-    const browser = await new Browser(app).navigateTo("/");
-
-    const targetNode = browser.document.getElementsByTagName("body")[0];
-    const config = { attributes: true, childList: true };
-
-    let childMutationCount = 0;
-
-    const observer = new browser.window.MutationObserver(function mutated() {
-      ++childMutationCount;
-      this.disconnect();
-    });
-    observer.observe(targetNode, config);
-
-    const p1 = browser.document.createElement("p");
-    targetNode.appendChild(p1);
-
-    const p2 = browser.document.createElement("p");
-    targetNode.appendChild(p2);
-
-    expect(childMutationCount).to.equal(1);
-  });
-
-  it("mutation when insertAdjacentHTML afterend triggers mutation on parent", async () => {
-    const browser = await new Browser(app).navigateTo("/");
-
-    const sequence = [];
-    const observer = new browser.window.MutationObserver(() => {
-      sequence.push("mutated");
-    });
-    observer.observe(browser.document.body, { childList: true });
-
-    const div = browser.document.createElement("div");
-
-    browser.document.body.lastElementChild.insertAdjacentHTML("afterend", div);
-
-    expect(sequence).to.eql([ "mutated" ]);
-  });
-
-  it("mutation when insertAdjacentHTML beforebegin triggers mutation on parent", async () => {
-    const browser = await new Browser(app).navigateTo("/");
-
-    const sequence = [];
-    const observer = new browser.window.MutationObserver(() => {
-      sequence.push("mutated");
-    });
-    observer.observe(browser.document.body, { childList: true });
-
-    const div = browser.document.createElement("div");
-
-    browser.document.body.lastElementChild.insertAdjacentHTML("beforebegin", div);
-
-    expect(sequence).to.eql([ "mutated" ]);
-  });
-
-  it("mutation when appendChild with script executes before mutation event", async () => {
-    const browser = await new Browser(app).navigateTo("/");
-
-    const sequence = browser.window.sequence = [];
-    const config = { attributes: true, childList: true };
-    const observer = new browser.window.MutationObserver(() => {
-      sequence.push("mutated");
-    });
-    observer.observe(browser.document.body, config);
-
-    const script = browser.document.createElement("script");
-    script.textContent = "window.sequence.push(\"executed\");";
-
-    browser.document.body.appendChild(script);
-
-    expect(sequence).to.eql([ "executed", "mutated" ]);
-  });
-
-  describe("MutationObserverInit options", () => {
-    let browser;
-    beforeEach(async () => {
-      browser = await new Browser(app).navigateTo("/");
-    });
-
-    it("observer with attributes option calls callback when element class changes", () => {
-      const records = [];
-      const observer = new browser.window.MutationObserver((mutatedRecords) => {
-        records.push(...mutatedRecords);
-      });
-      observer.observe(browser.document.body, { attributes: true });
-
-      browser.document.body.classList.add("mutate");
-
-      expect(records).to.have.length(1);
-
-      const record = records[0];
-      expect(record).to.have.property("type", "attributes");
-      expect(record).to.have.property("attributeName", "class");
-      expect(record.target === browser.document.body).to.be.true;
-    });
-
-    it("observer with attributes option calls callback when element attributes changes", () => {
-      browser.document.body.id = "existing";
-      const records = [];
-      const observer = new browser.window.MutationObserver((mutatedRecords) => {
-        records.push(...mutatedRecords);
-      });
-      observer.observe(browser.document.body, { attributes: true });
-
-      browser.document.body.attributes.id.value = "mutate";
-
-      expect(records).to.have.length(1);
-
-      const record = records[0];
-      expect(record).to.have.property("type", "attributes");
-      expect(record).to.have.property("attributeName", "id");
-      expect(record.target === browser.document.body).to.be.true;
-    });
-
-    it("observer with attributes and subtree option calls callback when element child src changes", () => {
-      const records = [];
-      const observer = new browser.window.MutationObserver((mutatedRecords) => {
-        records.push(...mutatedRecords);
-      });
-      observer.observe(browser.document.body, { attributes: true, subtree: true });
-
-      const img = browser.document.getElementsByTagName("img")[0];
-      img.src = "/images/tallahassee-2.png";
-
-      expect(records).to.have.length(1);
-
-      const record = records[0];
-      expect(record).to.have.property("type", "attributes");
-      expect(record).to.have.property("attributeName", "src");
-      expect(record.target === img).to.be.true;
-    });
-
-    it("observer with attributes doesn't call callback when element children changes", () => {
-      const records = [];
-      const observer = new browser.window.MutationObserver((mutatedRecords) => {
-        records.push(...mutatedRecords);
-      });
-      observer.observe(browser.document.body, { attributes: true });
-
-      const div = browser.document.createElement("div");
-      browser.document.body.appendChild(div);
-
-      expect(records).to.have.length(0);
-    });
-
-    it("observer with attributes calls callback when element attribute is removed", () => {
-      const records = [];
-      const observer = new browser.window.MutationObserver((mutatedRecords) => {
-        records.push(...mutatedRecords);
-      });
-      observer.observe(browser.document.body, { attributes: true });
-
-      browser.document.body.setAttribute("setattr", "1");
-
-      expect(records.length).to.equal(1);
-
-      expect(records[0]).to.have.property("attributeName", "setattr");
-
-      browser.document.body.removeAttribute("setattr");
-
-      expect(records.length).to.equal(2);
-      expect(records[1]).to.have.property("attributeName", "setattr");
-    });
-
-    it("observer with attributes doesn't call callback when non-existing element attribute is removed", () => {
-      const records = [];
-      const observer = new browser.window.MutationObserver((mutatedRecords) => {
-        records.push(...mutatedRecords);
-      });
-      observer.observe(browser.document.body, { attributes: true });
-
-      browser.document.body.setAttribute("setattr", "1");
-
-      expect(records.length).to.equal(1);
-
-      expect(records[0]).to.have.property("attributeName", "setattr");
-
-      browser.document.body.removeAttribute("setattr");
-
-      expect(records.length).to.equal(2);
-      expect(records[1]).to.have.property("attributeName", "setattr");
-
-      browser.document.body.removeAttribute("setattr");
-
-      expect(records.length).to.equal(2);
-    });
-
-    it("observer with attributes calls callback when element dataset changes", () => {
-      browser.document.body.setAttribute("data-count", "1");
-      const records = [];
-      const observer = new browser.window.MutationObserver((mutatedRecords) => {
-        records.push(...mutatedRecords);
-      });
-      observer.observe(browser.document.body, { attributes: true });
-
-      browser.document.body.dataset.count = "2";
-
-      expect(records.length).to.equal(1);
-
-      expect(records[0]).to.have.property("attributeName", "data-count");
     });
   });
 });

--- a/test/mutation-observer-test.js
+++ b/test/mutation-observer-test.js
@@ -49,12 +49,11 @@ describe("MutationObserver", () => {
         });
       });
 
-      it.skip("character data mutation", () => {
+      it("character data mutation", () => {
         element.textContent = "Welcome to…";
         expect(mutations).to.deep.equal({
           attributes: options.attributes ? 1 : 0,
-          // characterData: options.characterData ? 1 : 0,
-          characterData: 0,
+          characterData: options.characterData ? 1 : 0,
           childList: 0,
         });
       });
@@ -65,8 +64,7 @@ describe("MutationObserver", () => {
         element.appendChild(childElement);
         expect(mutations).to.deep.equal({
           attributes: options.attributes ? 1 : 0,
-          // characterData: options.characterData ? 1 : 0,
-          characterData: 0,
+          characterData: options.characterData ? 1 : 0,
           childList: options.childList ? 1 : 0,
         });
       });
@@ -77,33 +75,29 @@ describe("MutationObserver", () => {
           options.subtree ?
             {
               attributes: options.attributes ? 2 : 0,
-              // characterData: options.characterData ? 1 : 0,
-              characterData: 0,
+              characterData: options.characterData ? 1 : 0,
               childList: options.childList ? 1 : 0,
             } :
             {
               attributes: options.attributes ? 1 : 0,
-              // characterData: options.characterData ? 1 : 0,
-              characterData: 0,
+              characterData: options.characterData ? 1 : 0,
               childList: options.childList ? 1 : 0,
             }
         );
       });
 
-      it.skip("character data mutation in subtree", () => {
+      it("character data mutation in subtree", () => {
         childElement.textContent = "Tallahassee";
         expect(mutations).to.deep.equal(
           options.subtree ?
             {
               attributes: options.attributes ? 2 : 0,
-              // characterData: options.characterData ? 2 : 0,
-              characterData: 0,
+              characterData: options.characterData ? 2 : 0,
               childList: options.childList ? 1 : 0,
             } :
             {
               attributes: options.attributes ? 1 : 0,
-              // characterData: options.characterData ? 1 : 0,
-              characterData: 0,
+              characterData: options.characterData ? 1 : 0,
               childList: options.childList ? 1 : 0,
             }
         );
@@ -117,26 +111,20 @@ describe("MutationObserver", () => {
           options.subtree ?
             {
               attributes: options.attributes ? 2 : 0,
-              // characterData: options.characterData ? 2 : 0,
-              characterData: 0,
+              characterData: options.characterData ? 2 : 0,
               childList: options.childList ? 2 : 0,
             } :
             {
               attributes: options.attributes ? 1 : 0,
-              // characterData: options.characterData ? 1 : 0,
-              characterData: 0,
+              characterData: options.characterData ? 1 : 0,
               childList: options.childList ? 1 : 0,
             }
         );
       });
 
       function recordMutations(mutationsList) {
-        for (const mutation of mutationsList) {
-          if (mutation.type === "childList") {
-            mutations.childList++;
-          } else if (mutation.type === "attributes") {
-            mutations.attributes++;
-          }
+        for (const { type } of mutationsList) {
+          mutations[type]++;
         }
       }
     });

--- a/test/mutation-observer-test.js
+++ b/test/mutation-observer-test.js
@@ -49,11 +49,12 @@ describe("MutationObserver", () => {
         });
       });
 
-      it("character data mutation", () => {
+      it.skip("character data mutation", () => {
         element.textContent = "Welcome to…";
         expect(mutations).to.deep.equal({
           attributes: options.attributes ? 1 : 0,
-          characterData: options.characterData ? 1 : 0,
+          // characterData: options.characterData ? 1 : 0,
+          characterData: 0,
           childList: 0,
         });
       });
@@ -64,7 +65,8 @@ describe("MutationObserver", () => {
         element.appendChild(childElement);
         expect(mutations).to.deep.equal({
           attributes: options.attributes ? 1 : 0,
-          characterData: options.characterData ? 1 : 0,
+          // characterData: options.characterData ? 1 : 0,
+          characterData: 0,
           childList: options.childList ? 1 : 0,
         });
       });
@@ -75,29 +77,33 @@ describe("MutationObserver", () => {
           options.subtree ?
             {
               attributes: options.attributes ? 2 : 0,
-              characterData: options.characterData ? 1 : 0,
+              // characterData: options.characterData ? 1 : 0,
+              characterData: 0,
               childList: options.childList ? 1 : 0,
             } :
             {
               attributes: options.attributes ? 1 : 0,
-              characterData: options.characterData ? 1 : 0,
+              // characterData: options.characterData ? 1 : 0,
+              characterData: 0,
               childList: options.childList ? 1 : 0,
             }
         );
       });
 
-      it("character data mutation in subtree", () => {
+      it.skip("character data mutation in subtree", () => {
         childElement.textContent = "Tallahassee";
         expect(mutations).to.deep.equal(
           options.subtree ?
             {
               attributes: options.attributes ? 2 : 0,
-              characterData: options.characterData ? 2 : 0,
+              // characterData: options.characterData ? 2 : 0,
+              characterData: 0,
               childList: options.childList ? 1 : 0,
             } :
             {
               attributes: options.attributes ? 1 : 0,
-              characterData: options.characterData ? 1 : 0,
+              // characterData: options.characterData ? 1 : 0,
+              characterData: 0,
               childList: options.childList ? 1 : 0,
             }
         );
@@ -111,12 +117,14 @@ describe("MutationObserver", () => {
           options.subtree ?
             {
               attributes: options.attributes ? 2 : 0,
-              characterData: options.characterData ? 2 : 0,
+              // characterData: options.characterData ? 2 : 0,
+              characterData: 0,
               childList: options.childList ? 2 : 0,
             } :
             {
               attributes: options.attributes ? 1 : 0,
-              characterData: options.characterData ? 1 : 0,
+              // characterData: options.characterData ? 1 : 0,
+              characterData: 0,
               childList: options.childList ? 1 : 0,
             }
         );

--- a/test/mutation-observer-test.js
+++ b/test/mutation-observer-test.js
@@ -9,19 +9,15 @@ const Browser = require("../index.js");
 describe("MutationObserver", () => {
   [
     { attributes: true },
-    { characterData: true },
     { childList: true },
-    { attributes: true, characterData: true, childList: true },
+    { attributes: true, childList: true },
     { attributes: true, subtree: true },
-    { characterData: true, subtree: true },
     { childList: true, subtree: true },
-    { attributes: true, characterData: true, childList: true, subtree: true },
-    {},
+    { attributes: true, childList: true, subtree: true },
   ].forEach((options) => {
     describe(`options: ${JSON.stringify(options)}`, () => {
       const mutations = {
         attributes: 0,
-        characterData: 0,
         childList: 0,
       };
       let browser, element;
@@ -35,7 +31,6 @@ describe("MutationObserver", () => {
       it("no mutations", () => {
         expect(mutations).to.deep.equal({
           attributes: 0,
-          characterData: 0,
           childList: 0,
         });
       });
@@ -44,16 +39,6 @@ describe("MutationObserver", () => {
         element.setAttribute("lang", "en");
         expect(mutations).to.deep.equal({
           attributes: options.attributes ? 1 : 0,
-          characterData: 0,
-          childList: 0,
-        });
-      });
-
-      it("character data mutation", () => {
-        element.textContent = "Welcome to…";
-        expect(mutations).to.deep.equal({
-          attributes: options.attributes ? 1 : 0,
-          characterData: options.characterData ? 1 : 0,
           childList: 0,
         });
       });
@@ -64,7 +49,6 @@ describe("MutationObserver", () => {
         element.appendChild(childElement);
         expect(mutations).to.deep.equal({
           attributes: options.attributes ? 1 : 0,
-          characterData: options.characterData ? 1 : 0,
           childList: options.childList ? 1 : 0,
         });
       });
@@ -75,48 +59,25 @@ describe("MutationObserver", () => {
           options.subtree ?
             {
               attributes: options.attributes ? 2 : 0,
-              characterData: options.characterData ? 1 : 0,
               childList: options.childList ? 1 : 0,
             } :
             {
               attributes: options.attributes ? 1 : 0,
-              characterData: options.characterData ? 1 : 0,
-              childList: options.childList ? 1 : 0,
-            }
-        );
-      });
-
-      it("character data mutation in subtree", () => {
-        childElement.textContent = "Tallahassee";
-        expect(mutations).to.deep.equal(
-          options.subtree ?
-            {
-              attributes: options.attributes ? 2 : 0,
-              characterData: options.characterData ? 2 : 0,
-              childList: options.childList ? 1 : 0,
-            } :
-            {
-              attributes: options.attributes ? 1 : 0,
-              characterData: options.characterData ? 1 : 0,
               childList: options.childList ? 1 : 0,
             }
         );
       });
 
       it("child list mutation in subtree", () => {
-        const descendantElement = browser.document.createElement("img");
-        descendantElement.src = "/banjo+hat.jpg";
-        childElement.appendChild(descendantElement);
+        childElement.textContent = "Welcome to Tallahassee!";
         expect(mutations).to.deep.equal(
           options.subtree ?
             {
               attributes: options.attributes ? 2 : 0,
-              characterData: options.characterData ? 2 : 0,
               childList: options.childList ? 2 : 0,
             } :
             {
               attributes: options.attributes ? 1 : 0,
-              characterData: options.characterData ? 1 : 0,
               childList: options.childList ? 1 : 0,
             }
         );
@@ -351,12 +312,12 @@ describe("MutationObserver", () => {
     const browser = await new Browser(app).navigateTo("/");
 
     const targetNode = browser.document.getElementsByTagName("body")[0];
-    const config = { characterData: true };
-    let characterDataMutation = false;
+    const config = { childList: true };
+    let childListMutation = false;
     const callback = function (mutationsList) {
       for (const mutation of mutationsList) {
-        if (mutation.type === "characterData") {
-          characterDataMutation = true;
+        if (mutation.type === "childList") {
+          childListMutation = true;
         }
       }
     };
@@ -364,19 +325,19 @@ describe("MutationObserver", () => {
     observer.observe(targetNode, config);
 
     targetNode.textContent = "Foo";
-    expect(characterDataMutation).to.be.ok;
+    expect(childListMutation).to.be.ok;
   });
 
   it("triggers when element has been inserted into the observed node using innerText", async () => {
     const browser = await new Browser(app).navigateTo("/");
 
     const targetNode = browser.document.getElementsByTagName("body")[0];
-    const config = { characterData: true };
-    let characterDataMutation = false;
+    const config = { childList: true };
+    let childListMutation = false;
     const callback = function (mutationsList) {
       for (const mutation of mutationsList) {
-        if (mutation.type === "characterData") {
-          characterDataMutation = true;
+        if (mutation.type === "childList") {
+          childListMutation = true;
         }
       }
     };
@@ -384,7 +345,7 @@ describe("MutationObserver", () => {
     observer.observe(targetNode, config);
 
     targetNode.innerText = "Foo";
-    expect(characterDataMutation).to.be.ok;
+    expect(childListMutation).to.be.ok;
   });
 
   it("triggers when element has been removed from the observed node using removeChild", async () => {


### PR DESCRIPTION
## Add support for `option.subtree`

Mutation observers currently runs callback for any mutation in the subtree regardless of the option. May cause callback to run unexpectedly.

Old internal events `_insert` / `_attributeChange` have been replaced with `_mutation` and mutation argument with `type`.

## Notes

Tried to convert code to regular events with bubbling. Test ran in EXP Web and found issues with race conditions. An `HTMLCollection` retrieved from `document.getElementsByTagName` was updated after a Mutation Observer / event listener for said mutation. Unclear why.
