### PR TITLE
Add MessageEvent support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## 16.1.0
+
+- Add partial support for `MessageEvent`
+
 ## 16.0.6
 
 - Resolve weird issue with mutation observer callback occurring after disconnect

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,5 +1,5 @@
 <!-- version -->
-# 16.0.6 API Reference
+# 16.1.0 API Reference
 <!-- versionstop -->
 
 <!-- toc -->

--- a/lib/Events.js
+++ b/lib/Events.js
@@ -3,6 +3,8 @@
 const cancelBubbleSymbol = Symbol.for("cancelBubble");
 const defaultPreventedSymbol = Symbol.for("defaultPrevented");
 const detailSymbol = Symbol.for("detail");
+const dataSymbol = Symbol.for("data");
+const originSymbol = Symbol.for("origin");
 const kSubmitter = Symbol.for("submitter");
 const stateSymbol = Symbol.for("state");
 
@@ -59,6 +61,20 @@ class CustomEvent extends Event {
   }
 }
 
+class MessageEvent extends Event {
+  constructor(type, options) {
+    super(type = "message", options);
+    this[dataSymbol] = options?.data ?? null;
+    this[originSymbol] = options?.origin ?? "";
+  }
+  get data() {
+    return this[dataSymbol];
+  }
+  get origin() {
+    return this[originSymbol];
+  }
+}
+
 class SubmitEvent extends Event {
   constructor(type, options = {}) {
     super(type, { ...options, bubbles: true });
@@ -112,6 +128,7 @@ const symbols = { submitter: kSubmitter };
 module.exports = {
   Event,
   CustomEvent,
+  MessageEvent,
   InputEvent,
   FocusEvent,
   PointerEvent,

--- a/lib/Window.js
+++ b/lib/Window.js
@@ -4,7 +4,7 @@ const { EventEmitter } = require("events");
 const { performance } = require("perf_hooks");
 
 const { atob, btoa } = require("./atobtoa.js");
-const { Event, CustomEvent, KeyboardEvent } = require("./Events.js");
+const { Event, CustomEvent, KeyboardEvent, MessageEvent } = require("./Events.js");
 const CustomElementRegistry = require("./CustomElementRegistry.js");
 const Element = require("./Element.js");
 const EventTarget = require("./EventTarget.js");
@@ -147,6 +147,9 @@ module.exports = class Window extends EventTarget {
   }
   get CustomEvent() {
     return CustomEvent;
+  }
+  get MessageEvent() {
+    return MessageEvent;
   }
   matchMedia(mediaQueryString) {
     return new MediaQueryList(this, mediaQueryString, this[kOptions]?.matchMedia);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expressen/tallahassee",
-  "version": "16.0.6",
+  "version": "16.1.0",
   "description": "Lightweight client testing framework",
   "main": "index.js",
   "license": "BSD-3-Clause",

--- a/test/events-test.js
+++ b/test/events-test.js
@@ -114,4 +114,37 @@ describe("Events", () => {
       });
     });
   });
+
+  describe("MessageEvent", () => {
+    it("creates an object with the expected properties", async () => {
+      const browser = await new Browser(app).navigateTo("/");
+
+      let interceptedEvent;
+      browser.window.addEventListener("message", (event) => {
+        interceptedEvent = event;
+      });
+
+      browser.window.dispatchEvent(
+        new browser.window.MessageEvent("message")
+      );
+
+      expect(interceptedEvent).to.be.ok;
+      expect(interceptedEvent).to.have.property("type", "message");
+      expect(interceptedEvent).to.have.property("data", null);
+      expect(interceptedEvent).to.have.property("origin", "");
+
+      browser.window.dispatchEvent(
+        new browser.window.MessageEvent("foo", {
+          data: "fooBar",
+          origin: "http://foo.bar",
+        })
+      );
+
+      expect(interceptedEvent).to.be.ok;
+      expect(interceptedEvent).to.have.property("type", "message");
+      expect(interceptedEvent).to.have.property("data", "fooBar");
+      expect(interceptedEvent).to.have.property("origin", "http://foo.bar");
+    });
+  });
+
 });


### PR DESCRIPTION
Basic support for [MessageEvent](https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent)

The need for our website was just to use a MessageEvent with `data` and `origin` so we will not support every single prop
